### PR TITLE
Laravel 5+ cache .

### DIFF
--- a/src/Cache/LaravelCache
+++ b/src/Cache/LaravelCache
@@ -1,6 +1,6 @@
 <?php namespace App\Geotools\Cache;
 
-use Illuminate\Contracts\Cache\Store;
+use Illuminate\Cache\Repository;
 use League\Geotools\Batch\BatchGeocoded;
 use League\Geotools\Cache\AbstractCache;
 use League\Geotools\Cache\CacheInterface;
@@ -31,7 +31,7 @@ class LaravelCache extends AbstractCache implements CacheInterface
      * @param Store $cache
      * @param int $expire
      */
-    public function __construct(Store $cache, $expire = 0)
+    public function __construct(Repository $cache, $expire = 0)
     {
         $this->cache = $cache;
         $this->expire = $expire;
@@ -70,7 +70,7 @@ class LaravelCache extends AbstractCache implements CacheInterface
             $this->cache->put(
                 $this->getKey($geocoded->getProviderName(), $geocoded->getQuery()),
                 $this->serialize($geocoded),
-                Carbon::now()->addMinutes($this->expire)
+                 Carbon::now()->addMinutes($this->expire)
             );
         }
 

--- a/src/Cache/LaravelCache
+++ b/src/Cache/LaravelCache
@@ -1,0 +1,110 @@
+<?php namespace App\Geotools\Cache;
+
+use Illuminate\Contracts\Cache\Store;
+use League\Geotools\Batch\BatchGeocoded;
+use League\Geotools\Cache\AbstractCache;
+use League\Geotools\Cache\CacheInterface;
+use League\Geotools\Cache\RuntimException;
+
+/**
+ * Created by Jason Kristian.
+ * Project: WebApplication
+ * Author: jasonkristian
+ * Date: 28/06/15
+ * Time: 5:40 AM
+ */
+class LaravelCache extends AbstractCache implements CacheInterface
+{
+    /**
+     * The expire value for keys.
+     *
+     * @var integer
+     */
+    protected $expire;
+    /**
+     * @var
+     */
+    private $cache;
+
+    /**
+     * LaravelCache constructor.
+     * @param Store $cache
+     * @param int $expire
+     */
+    public function __construct(Store $cache, $expire = 0)
+    {
+        $this->cache = $cache;
+        $this->expire = $expire;
+    }
+
+
+    /**
+     * Return a unique key.
+     *
+     * @param string $providerName The name of the provider.
+     * @param string $query The query string.
+     *
+     * @return string The unique key.
+     */
+    public function getKey($providerName, $query)
+    {
+        // TODO: Implement getKey() method.
+        return md5($providerName . $query);
+    }
+
+    /**
+     * Add into the cache.
+     *
+     * @param BatchGeocoded $geocoded The BatchGeocoded object to cache.
+     *
+     * @throws RuntimException
+     */
+    public function cache(BatchGeocoded $geocoded)
+    {
+        if($this->expire == 0 ) {
+            $this->cache->forever(
+                $this->getKey($geocoded->getProviderName(), $geocoded->getQuery()),
+                $this->serialize($geocoded)
+            );
+        } else {
+            $this->cache->put(
+                $this->getKey($geocoded->getProviderName(), $geocoded->getQuery()),
+                $this->serialize($geocoded),
+                $expiresAt = Carbon::now()->addMinutes($this->expire)
+            );
+        }
+
+    }
+
+    /**
+     * Check against the cache instance if any.
+     *
+     * @param string $providerName The name of the provider.
+     * @param string $query The query string.
+     *
+     * @return boolean|BatchGeocoded The BatchGeocoded if cached false otherwise.
+     */
+    public function isCached($providerName, $query)
+    {
+        // TODO: Implement isCached() method.
+        $key = $this->getKey($providerName, $query);
+        if( ! $this->cache->has($key)){
+                return false;
+        }
+
+        $cached = new BatchGeocoded();
+        $cached->fromArray($this->deserialize($this->cache->get($key)));
+
+        return $cached;
+
+    }
+
+    /**
+     * Delete cached tuple.
+     */
+    public function flush()
+    {
+        $this->cache->flush();
+    }
+
+}

--- a/src/Cache/LaravelCache
+++ b/src/Cache/LaravelCache
@@ -5,13 +5,13 @@ use League\Geotools\Batch\BatchGeocoded;
 use League\Geotools\Cache\AbstractCache;
 use League\Geotools\Cache\CacheInterface;
 use League\Geotools\Cache\RuntimException;
-
-/**
- * Created by Jason Kristian.
- * Project: WebApplication
- * Author: jasonkristian
- * Date: 28/06/15
- * Time: 5:40 AM
+/*
+ * This file is part of the Geotools library.
+ *
+ * (c) Antoine Corcy <contact@sbin.dk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 class LaravelCache extends AbstractCache implements CacheInterface
 {

--- a/src/Cache/LaravelCache
+++ b/src/Cache/LaravelCache
@@ -70,7 +70,7 @@ class LaravelCache extends AbstractCache implements CacheInterface
             $this->cache->put(
                 $this->getKey($geocoded->getProviderName(), $geocoded->getQuery()),
                 $this->serialize($geocoded),
-                $expiresAt = Carbon::now()->addMinutes($this->expire)
+                Carbon::now()->addMinutes($this->expire)
             );
         }
 


### PR DESCRIPTION
Use built in cache of laravel 5 framework. AS the Laravel framework and Geotools use the same backends for caching  might as well just use one instance . eg: if Im using Redis for Laravel Cache and Geotools cache by using the frameworks cache for geotools I only need to manage cache settings in one place and easy to change cache backend's and have the framework and GeoTools updated to new backend.