### PR TITLE
[BUG] fix the polygon construct

### DIFF
--- a/src/Polygon/Polygon.php
+++ b/src/Polygon/Polygon.php
@@ -48,18 +48,16 @@ class Polygon extends \League\Geotools\AbstractGeotools implements PolygonInterf
      */
     public function __construct($coordinates = null)
     {
-        if (is_array($coordinates) || null === $coordinates) {
-            $this->coordinates = new CoordinateCollection;
-        } elseif ($coordinates instanceof CoordinateCollection) {
+        if ($coordinates instanceof CoordinateCollection) {
             $this->coordinates = $coordinates;
+        } elseif (is_array($coordinates)) {
+            $this->set($coordinates);
+            $this->boundingBox = new BoundingBox($this);
+        } elseif (empty($coordinates)) {
+            $this->coordinates = new CoordinateCollection;
+            $this->boundingBox = new BoundingBox($this);
         } else {
             throw new \InvalidArgumentException;
-        }
-
-        $this->boundingBox = new BoundingBox($this);
-
-        if (is_array($coordinates)) {
-            $this->set($coordinates);
         }
     }
 


### PR DESCRIPTION
The first test in the construct function is checking if the coordinates parameter is an array or null
then create a new CoordinateCollection
but a later test is using the set function when the parameter is an array then erases this new Coordinates collection.
So i rewamped the function keep thes argument tests but without the useless Coordinatecollection creation.