### PR TITLE
Fix setAdminLevels in AbstractCache.

### DIFF
--- a/src/Cache/AbstractCache.php
+++ b/src/Cache/AbstractCache.php
@@ -72,7 +72,7 @@ abstract class AbstractCache
      */
     protected function setAdminLevels($array)
     {
-        foreach ($array['adminLevels'] as $level => &$adminLevel) {
+        foreach ($array['address']['adminLevels'] as $level => &$adminLevel) {
             $adminLevel['level'] = $level;
         }
 


### PR DESCRIPTION
Hey,

I noticed this bug when I updated to 0.5. 
The setAdminLevels function expected the `adminLevels` key to be in the main array, however the actual cached object has the `adminLevels` key in the `address` subarray