### PR TITLE
Fixes for phpDoc autocompletion

### DIFF
--- a/src/AbstractGeotools.php
+++ b/src/AbstractGeotools.php
@@ -88,14 +88,14 @@ abstract class AbstractGeotools
     /**
      * The origin coordinate.
      *
-     * @var CoordinateInterface
+     * @var \League\Geotools\Coordinate\CoordinateInterface
      */
     protected $from;
 
     /**
      * The destination coordinate.
      *
-     * @var CoordinateInterface
+     * @var \League\Geotools\Coordinate\CoordinateInterface
      */
     protected $to;
 }

--- a/src/Batch/BatchInterface.php
+++ b/src/Batch/BatchInterface.php
@@ -36,7 +36,7 @@ interface BatchInterface
      * Set an array of closures to reverse geocode.
      * If a provider throws an exception it will return an empty AddressCollection.
      *
-     * @param CoordinateInterface|array $coordinates A coordinate or an array of coordinates to reverse.
+     * @param \League\Geotools\Coordinate\CoordinateInterface|array $coordinates A coordinate or an array of coordinates to reverse.
      *
      * @return BatchInterface
      *

--- a/src/Cache/AbstractCache.php
+++ b/src/Cache/AbstractCache.php
@@ -42,7 +42,7 @@ abstract class AbstractCache
      * @todo There is an issue while serializing the Country object in JSON.
      * The country has the Country object (name and code) instead to have the country name.
      *
-     * @param BatchGeocoded $object The BatchGeocoded object to serialize.
+     * @param \League\Geotools\Batch\BatchGeocoded $object The BatchGeocoded object to serialize.
      *
      * @return string The serialized object in json.
      */

--- a/src/Cache/AbstractCache.php
+++ b/src/Cache/AbstractCache.php
@@ -25,7 +25,7 @@ abstract class AbstractCache
     /**
      * Normalize an object to array.
      *
-     * @param BatchGeocoded $object The BatchGeocoded object to normalize.
+     * @param \League\Geotools\Batch\BatchGeocoded $object The BatchGeocoded object to normalize.
      *
      * @return array The normalized object.
      */

--- a/src/Cache/Redis.php
+++ b/src/Cache/Redis.php
@@ -25,7 +25,7 @@ class Redis extends AbstractCache implements CacheInterface
     /**
      * The redis cache.
      *
-     * @var Predis
+     * @var \Predis\Client
      */
     protected $redis;
 

--- a/src/Convert/Convert.php
+++ b/src/Convert/Convert.php
@@ -217,7 +217,7 @@ class Convert extends AbstractGeotools implements ConvertInterface
         }
 
         return sprintf('%d%s %d %d',
-            $zone, $this->latitudeBands[(int) ($this->coordinates->getLatitude() + 80) / 8], $easting, $northing
+            $zone, $this->latitudeBands[(int) (($this->coordinates->getLatitude() + 80) / 8)], $easting, $northing
         );
     }
 

--- a/src/Coordinate/Ellipsoid.php
+++ b/src/Coordinate/Ellipsoid.php
@@ -11,7 +11,6 @@
 
 namespace League\Geotools\Coordinate;
 
-use League\Geotools\Coordinate\CoordinateInterface;
 use League\Geotools\Exception\InvalidArgumentException;
 use League\Geotools\Exception\NotMatchingEllipsoidException;
 

--- a/src/Distance/Distance.php
+++ b/src/Distance/Distance.php
@@ -11,7 +11,7 @@
 
 namespace League\Geotools\Distance;
 
-use League\Geootols\Exception\NotConvergingException;
+use League\Geotools\Exception\NotConvergingException;
 use League\Geotools\AbstractGeotools;
 use League\Geotools\Coordinate\CoordinateInterface;
 use League\Geotools\Coordinate\Ellipsoid;


### PR DESCRIPTION
Also fixed invalid namespace definition.

In `src/Convert/Convert.php` I replaced the implicit casting to `int` (it was tried to take an array element with `float` key) with explicit.

P.S. Sorry for Engrish.