### PR TITLE
Added some new geometry type and collection

### DIFF
--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -141,4 +141,23 @@ class ArrayCollection implements \Countable, \IteratorAggregate, \ArrayAccess, \
 
         return null;
     }
+
+    /**
+     * @param ArrayCollection $collection
+     * @return ArrayCollection
+     */
+    public function merge(ArrayCollection $collection)
+    {
+        $merged = clone $this;
+
+        foreach ($collection as $key => $element) {
+            if (is_int($key)) {
+                $merged->add($element);
+            } else {
+                $merged->set($key, $element);
+            }
+        }
+
+        return $merged;
+    }
 }

--- a/src/BoundingBox/BoundingBoxInterface.php
+++ b/src/BoundingBox/BoundingBoxInterface.php
@@ -11,6 +11,8 @@
 
 namespace League\Geotools\BoundingBox;
 
+use League\Geotools\Polygon\PolygonInterface;
+
 /**
  * @author Gabriel Bull <me@gabrielbull.com>
  */
@@ -35,4 +37,15 @@ interface BoundingBoxInterface
      * @return float|string|integer
      */
     public function getWest();
+
+    /**
+     * @return PolygonInterface
+     */
+    public function getAsPolygon();
+
+    /**
+     * @param  BoundingBoxInterface $boundingBox
+     * @return BoundingBoxInterface
+     */
+    public function merge(BoundingBoxInterface $boundingBox);
 }

--- a/src/Coordinate/CoordinateCollection.php
+++ b/src/Coordinate/CoordinateCollection.php
@@ -11,9 +11,91 @@
 
 namespace League\Geotools\Coordinate;
 
+use League\Geotools\ArrayCollection;
+use League\Geotools\Exception\InvalidArgumentException;
+
 /**
  * @author Gabriel Bull <me@gabrielbull.com>
  */
-class CoordinateCollection extends \League\Geotools\ArrayCollection
+class CoordinateCollection extends ArrayCollection
 {
+    /**
+     * @var Ellipsoid
+     */
+    private $ellipsoid;
+
+    /**
+     * CoordinateCollection constructor.
+     *
+     * @param CoordinateInterface[] $coordinates
+     * @param Ellipsoid             $ellipsoid
+     */
+    public function __construct(array $coordinates = array(), Ellipsoid $ellipsoid = null)
+    {
+        if ($ellipsoid) {
+            $this->ellipsoid = $ellipsoid;
+        } elseif (count($coordinates) > 0) {
+            $this->ellipsoid = reset($coordinates)->getEllipsoid();
+        }
+
+        $this->checkCoordinatesArray($coordinates);
+
+        parent::__construct($coordinates);
+    }
+
+    /**
+     * @param string     $key
+     * @param CoordinateInterface $value
+     */
+    public function set($key, $value)
+    {
+        $this->checkEllipsoid($value);
+        $this->elements[$key] = $value;
+    }
+
+    /**
+     * @param  CoordinateInterface $value
+     * @return bool
+     */
+    public function add($value)
+    {
+        $this->checkEllipsoid($value);
+        $this->elements[] = $value;
+
+        return true;
+    }
+
+    /**
+     * @return Ellipsoid
+     */
+    public function getEllipsoid()
+    {
+        return $this->ellipsoid;
+    }
+
+    /**
+     * @param array CoordinateInterface[] $coordinates
+     */
+    private function checkCoordinatesArray(array $coordinates)
+    {
+        foreach ($coordinates as $coordinate) {
+            $this->checkEllipsoid($coordinate);
+        }
+    }
+
+    /**
+     * @param CoordinateInterface $coordinate
+     *
+     * @throws InvalidArgumentException
+     */
+    private function checkEllipsoid(CoordinateInterface $coordinate)
+    {
+        if ($this->ellipsoid === null) {
+            $this->ellipsoid = $coordinate->getEllipsoid();
+        }
+
+        if ($coordinate->getEllipsoid() != $this->ellipsoid) {
+            throw new InvalidArgumentException("Ellipsoids don't match");
+        }
+    }
 }

--- a/src/GeometryCollection.php
+++ b/src/GeometryCollection.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the Geotools library.
+ *
+ * (c) Antoine Corcy <contact@sbin.dk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Geotools;
+
+use League\Geotools\BoundingBox\BoundingBox;
+use League\Geotools\BoundingBox\BoundingBoxInterface;
+use League\Geotools\Coordinate\Coordinate;
+use League\Geotools\Coordinate\CoordinateCollection;
+use League\Geotools\Coordinate\Ellipsoid;
+use League\Geotools\Exception\InvalidArgumentException;
+
+/**
+ * @author Rémi San <remi.san@gmail.com>
+ */
+abstract class GeometryCollection extends ArrayCollection implements GeometryInterface
+{
+    /**
+     * @var Ellipsoid
+     */
+    private $ellipsoid;
+
+    /**
+     * @var integer
+     */
+    private $precision;
+
+    /**
+     * CoordinateCollection constructor.
+     *
+     * @param GeometryInterface[] $geometries
+     * @param Ellipsoid             $ellipsoid
+     */
+    public function __construct(array $geometries = array(), Ellipsoid $ellipsoid = null)
+    {
+        $this->precision = -1;
+
+        $this->ellipsoid = $ellipsoid ? : null;
+
+        $this->checkGeometriesArray($geometries);
+
+        parent::__construct($geometries);
+    }
+
+    /**
+     * @return string
+     */
+    abstract public function getGeometryType();
+
+    /**
+     * @return integer
+     */
+    public function getPrecision()
+    {
+        return $this->precision;
+    }
+
+    /**
+     * @return Coordinate
+     */
+    public function getCoordinate()
+    {
+        if ($this->isEmpty()) {
+            return null;
+        }
+
+        return $this->offsetGet(0)->getCoordinate();
+    }
+
+    /**
+     * @return CoordinateCollection
+     */
+    public function getCoordinates()
+    {
+        $coordinates = new CoordinateCollection(array(), $this->ellipsoid);
+
+        /** @var GeometryInterface $element */
+        foreach ($this->elements as $element) {
+            $coordinates = $coordinates->merge($element->getCoordinates());
+        }
+
+        return $coordinates;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isEmpty()
+    {
+        return count($this->elements) === 0 ;
+    }
+
+    /**
+     * @return BoundingBoxInterface
+     */
+    public function getBoundingBox()
+    {
+        $boundingBox = new BoundingBox();
+
+        /** @var GeometryInterface $element */
+        foreach ($this->elements as $element) {
+            $boundingBox = $boundingBox->merge($element->getBoundingBox());
+        }
+
+        return $boundingBox;
+    }
+
+    /**
+     * @param string            $key
+     *
+     * @param GeometryInterface $value
+     */
+    public function set($key, $value)
+    {
+        $this->checkEllipsoid($value);
+        $this->elements[$key] = $value;
+    }
+
+    /**
+     * @param  GeometryInterface $value
+     *
+     * @return bool
+     */
+    public function add($value)
+    {
+        $this->checkEllipsoid($value);
+        $this->elements[] = $value;
+
+        return true;
+    }
+
+    /**
+     * @return Ellipsoid
+     */
+    public function getEllipsoid()
+    {
+        return $this->ellipsoid;
+    }
+
+    /**
+     * @param array GeometryInterface[] $geometries
+     */
+    private function checkGeometriesArray(array $geometries)
+    {
+        foreach ($geometries as $geometry) {
+            if (!$geometry instanceof GeometryInterface) {
+                throw new InvalidArgumentException("You didn't provide a geometry!");
+            }
+            $this->checkEllipsoid($geometry);
+        }
+    }
+
+    /**
+     * @param GeometryInterface $geometry
+     *
+     * @throws InvalidArgumentException
+     */
+    private function checkEllipsoid(GeometryInterface $geometry)
+    {
+        if (bccomp($geometry->getPrecision(), $this->precision) === 1) {
+            $this->precision = $geometry->getPrecision();
+        }
+
+        if ($this->ellipsoid === null) {
+            $this->ellipsoid = $geometry->getEllipsoid();
+        } elseif ($geometry->isEmpty() || $geometry->getEllipsoid() != $this->ellipsoid) {
+            throw new InvalidArgumentException("Geometry is invalid");
+        }
+    }
+
+    /**
+     * @param  ArrayCollection $collection
+     *
+     * @return ArrayCollection
+     */
+    public function merge(ArrayCollection $collection)
+    {
+        if (!$collection instanceof GeometryCollection || $collection->getGeometryType() !== $this->getGeometryType()) {
+            throw new InvalidArgumentException("Collections types don't match, you can't merge.");
+        }
+
+        return parent::merge($collection);
+    }
+}

--- a/src/GeometryInterface.php
+++ b/src/GeometryInterface.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Geotools library.
+ *
+ * (c) Antoine Corcy <contact@sbin.dk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Geotools;
+
+use League\Geotools\BoundingBox\BoundingBoxInterface;
+use League\Geotools\Coordinate\Coordinate;
+use League\Geotools\Coordinate\CoordinateCollection;
+use League\Geotools\Coordinate\Ellipsoid;
+
+/**
+ * @author Rémi San <remi.san@gmail.com>
+ */
+interface GeometryInterface
+{
+    /**
+     * Returns the geometry type.
+     *
+     * @return string
+     */
+    public function getGeometryType();
+
+    /**
+     * Returns the ellipsoid of the geometry.
+     *
+     * @return Ellipsoid
+     */
+    public function getEllipsoid();
+
+    /**
+     * Returns the precision of the geometry.
+     *
+     * @return integer
+     */
+    public function getPrecision();
+
+    /**
+     *  Returns a vertex of this <code>Geometry</code> (usually, but not necessarily, the first one).
+     *  The returned coordinate should not be assumed to be an actual Coordinate object used in
+     *  the internal representation.
+     *
+     * @return Coordinate if there's a coordinate in the collection
+     * @return null if this Geometry is empty
+     */
+    public function getCoordinate();
+
+    /**
+     *  Returns a collection containing the values of all the vertices for this geometry.
+     *  If the geometry is a composite, the array will contain all the vertices
+     *  for the components, in the order in which the components occur in the geometry.
+     *
+     *@return CoordinateCollection the vertices of this <code>Geometry</code>
+     */
+    public function getCoordinates();
+
+    /**
+     * Returns true if the geometry is empty.
+     *
+     * @return boolean
+     */
+    public function isEmpty();
+
+    /**
+     * Returns the bounding box of the Geometry
+     *
+     * @return BoundingBoxInterface
+     */
+    public function getBoundingBox();
+}

--- a/src/Polygon/MultiPolygon.php
+++ b/src/Polygon/MultiPolygon.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace League\Geotools\Polygon;
+
+use League\Geotools\Coordinate\CoordinateInterface;
+use League\Geotools\GeometryCollection;
+
+class MultiPolygon extends GeometryCollection implements PolygonInterface
+{
+    const TYPE = 'MULTIPOLYGON';
+
+    /**
+     * @return string
+     */
+    public function getGeometryType()
+    {
+        return self::TYPE;
+    }
+
+    /**
+     * @param  CoordinateInterface $coordinate
+     * @return boolean
+     */
+    public function pointInPolygon(CoordinateInterface $coordinate)
+    {
+        /** @var PolygonInterface $polygon */
+        foreach ($this->elements as $polygon) {
+            if ($polygon->pointInPolygon($coordinate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  CoordinateInterface $coordinate
+     * @return boolean
+     */
+    public function pointOnBoundary(CoordinateInterface $coordinate)
+    {
+        /** @var PolygonInterface $polygon */
+        foreach ($this->elements as $polygon) {
+            if ($polygon->pointOnBoundary($coordinate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  CoordinateInterface $coordinate
+     * @return boolean
+     */
+    public function pointOnVertex(CoordinateInterface $coordinate)
+    {
+        /** @var PolygonInterface $polygon */
+        foreach ($this->elements as $polygon) {
+            if ($polygon->pointOnVertex($coordinate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Polygon/Polygon.php
+++ b/src/Polygon/Polygon.php
@@ -11,20 +11,24 @@
 
 namespace League\Geotools\Polygon;
 
+use League\Geotools\AbstractGeotools;
 use League\Geotools\BoundingBox\BoundingBox;
 use League\Geotools\BoundingBox\BoundingBoxInterface;
 use League\Geotools\Coordinate\Coordinate;
 use League\Geotools\Coordinate\CoordinateCollection;
 use League\Geotools\Coordinate\CoordinateInterface;
+use League\Geotools\Coordinate\Ellipsoid;
 
 /**
  * @author Gabriel Bull <me@gabrielbull.com>
  */
-class Polygon extends \League\Geotools\AbstractGeotools implements PolygonInterface, \Countable, \IteratorAggregate,
-    \ArrayAccess, \JsonSerializable
+class Polygon extends AbstractGeotools implements PolygonInterface, \Countable,
+    \IteratorAggregate, \ArrayAccess, \JsonSerializable
 {
+    const TYPE = 'POLYGON';
+
     /**
-     * @var CoordinateCollection|CoordinateInterface[]
+     * @var CoordinateCollection
      */
     private $coordinates;
 
@@ -52,6 +56,7 @@ class Polygon extends \League\Geotools\AbstractGeotools implements PolygonInterf
             $this->coordinates = new CoordinateCollection;
         } elseif ($coordinates instanceof CoordinateCollection) {
             $this->coordinates = $coordinates;
+            $this->hasCoordinate = $coordinates->count() > 0;
         } else {
             throw new \InvalidArgumentException;
         }
@@ -62,6 +67,39 @@ class Polygon extends \League\Geotools\AbstractGeotools implements PolygonInterf
             $this->set($coordinates);
         }
     }
+
+    /**
+     * @return string
+     */
+    public function getGeometryType()
+    {
+        return self::TYPE;
+    }
+
+    /**
+     * @return Ellipsoid
+     */
+    public function getEllipsoid()
+    {
+        return $this->coordinates->getEllipsoid();
+    }
+
+    /**
+     * @return Coordinate
+     */
+    public function getCoordinate()
+    {
+        return $this->coordinates->offsetGet(0);
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isEmpty()
+    {
+        return !$this->hasCoordinate;
+    }
+
 
     /**
      * @param  CoordinateInterface $coordinate
@@ -91,12 +129,11 @@ class Polygon extends \League\Geotools\AbstractGeotools implements PolygonInterf
             $currentVertex = $this->get($i - 1);
             $nextVertex = $this->get($i);
 
-            if (
-                bccomp(
-                    $coordinate->getLatitude(),
-                    min($currentVertex->getLatitude(), $nextVertex->getLatitude()),
-                    $this->getPrecision()
-                ) === 1 &&
+            if (bccomp(
+                $coordinate->getLatitude(),
+                min($currentVertex->getLatitude(), $nextVertex->getLatitude()),
+                $this->getPrecision()
+            ) === 1 &&
                 bccomp(
                     $coordinate->getLatitude(),
                     max($currentVertex->getLatitude(), $nextVertex->getLatitude()),
@@ -119,12 +156,11 @@ class Polygon extends \League\Geotools\AbstractGeotools implements PolygonInterf
                     ($nextVertex->getLatitude() - $currentVertex->getLatitude()) +
                     $currentVertex->getLongitude();
 
-                if (
-                    bccomp(
-                        $currentVertex->getLongitude(),
-                        $nextVertex->getLongitude(),
-                        $this->getPrecision()
-                    ) === 0 ||
+                if (bccomp(
+                    $currentVertex->getLongitude(),
+                    $nextVertex->getLongitude(),
+                    $this->getPrecision()
+                ) === 0 ||
                     bccomp(
                         $coordinate->getLongitude(),
                         $xinters,
@@ -159,12 +195,11 @@ class Polygon extends \League\Geotools\AbstractGeotools implements PolygonInterf
             }
 
             // Check if coordinate is on a horizontal boundary
-            if (
-                bccomp(
-                    $currentVertex->getLatitude(),
-                    $nextVertex->getLatitude(),
-                    $this->getPrecision()
-                ) === 0 &&
+            if (bccomp(
+                $currentVertex->getLatitude(),
+                $nextVertex->getLatitude(),
+                $this->getPrecision()
+            ) === 0 &&
                 bccomp(
                     $currentVertex->getLatitude(),
                     $coordinate->getLatitude(),
@@ -185,12 +220,11 @@ class Polygon extends \League\Geotools\AbstractGeotools implements PolygonInterf
             }
 
             // Check if coordinate is on a boundary
-            if (
-                bccomp(
-                    $coordinate->getLatitude(),
-                    min($currentVertex->getLatitude(), $nextVertex->getLatitude()),
-                    $this->getPrecision()
-                ) === 1 &&
+            if (bccomp(
+                $coordinate->getLatitude(),
+                min($currentVertex->getLatitude(), $nextVertex->getLatitude()),
+                $this->getPrecision()
+            ) === 1 &&
                 bccomp(
                     $coordinate->getLatitude(),
                     max($currentVertex->getLatitude(), $nextVertex->getLatitude()),
@@ -229,12 +263,11 @@ class Polygon extends \League\Geotools\AbstractGeotools implements PolygonInterf
     public function pointOnVertex(CoordinateInterface $coordinate)
     {
         foreach ($this->coordinates as $vertexCoordinate) {
-            if (
-                bccomp(
-                    $vertexCoordinate->getLatitude(),
-                    $coordinate->getLatitude(),
-                    $this->getPrecision()
-                ) === 0 &&
+            if (bccomp(
+                $vertexCoordinate->getLatitude(),
+                $coordinate->getLatitude(),
+                $this->getPrecision()
+            ) === 0 &&
                 bccomp(
                     $vertexCoordinate->getLongitude(),
                     $coordinate->getLongitude(),

--- a/src/Polygon/PolygonInterface.php
+++ b/src/Polygon/PolygonInterface.php
@@ -11,46 +11,29 @@
 
 namespace League\Geotools\Polygon;
 
-use League\Geotools\Coordinate\CoordinateCollection;
 use League\Geotools\Coordinate\CoordinateInterface;
+use League\Geotools\GeometryInterface;
 
 /**
  * @author Gabriel Bull <me@gabrielbull.com>
  */
-interface PolygonInterface
+interface PolygonInterface extends GeometryInterface
 {
     /**
-     * @return CoordinateCollection
+     * @param  CoordinateInterface $coordinate
+     * @return boolean
      */
-    public function getCoordinates();
-
-    /**
-     * @param  CoordinateCollection $coordinates
-     * @return $this
-     */
-    public function setCoordinates(CoordinateCollection $coordinates);
-
-    /**
-     * @param  string                   $key
-     * @return null|CoordinateInterface
-     */
-    public function get($key);
-
-    /**
-     * @param string              $key
-     * @param CoordinateInterface $coordinate
-     */
-    public function set($key, CoordinateInterface $coordinate);
+    public function pointInPolygon(CoordinateInterface $coordinate);
 
     /**
      * @param  CoordinateInterface $coordinate
      * @return boolean
      */
-    public function add(CoordinateInterface $coordinate);
+    public function pointOnBoundary(CoordinateInterface $coordinate);
 
     /**
-     * @param  string                   $key
-     * @return null|CoordinateInterface
+     * @param  CoordinateInterface $coordinate
+     * @return boolean
      */
-    public function remove($key);
+    public function pointOnVertex(CoordinateInterface $coordinate);
 }

--- a/tests/ArrayCollectionTest.php
+++ b/tests/ArrayCollectionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace League\Geotools\Tests;
+
+use League\Geotools\ArrayCollection;
+
+class ArrayCollectionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itShouldBeConvertibleToArray()
+    {
+        $array = ['foo', 'bar'];
+
+        $collection = new ArrayCollection($array);
+
+        $this->assertEquals($array, $collection->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldSerializeTheInnerElements()
+    {
+        $array = ['foo', 'bar'];
+
+        $collection = new ArrayCollection($array);
+
+        $this->assertEquals(json_encode($array), json_encode($collection));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldBehaveAsAnArray()
+    {
+        $array = ['foo', 'baz'=>'bar'];
+
+        $collection = new ArrayCollection($array);
+
+        $this->assertEquals('foo', $collection[0]);
+        $this->assertFalse(isset($collection[99]));
+        $this->assertTrue(isset($collection['baz']));
+        $this->assertEquals('bar', $collection['baz']);
+
+        $collection[99] = 'dummy';
+        $this->assertEquals('dummy', $collection[99]);
+
+        unset($collection[99]);
+        $this->assertFalse(isset($collection[99]));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldBeCountable()
+    {
+        $array = ['foo', 'bar'];
+
+        $collection = new ArrayCollection($array);
+
+        $this->assertEquals(2, count($collection));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldOfferAccessToInnerElementsByKey()
+    {
+        $array = ['foo' => 'bar'];
+
+        $collection = new ArrayCollection($array);
+        $this->assertEquals('bar', $collection->get('foo'));
+
+        $collection->set('dummy', 'baz');
+        $this->assertEquals('baz', $collection->get('dummy'));
+        $this->assertNull($collection->get('bat'));
+
+        $collection->remove('dummy');
+        $this->assertNull($collection->get('dummy'));
+
+        $collection->add('baz');
+        $this->assertEquals('baz', $collection->get(0));
+
+        $this->assertNull($collection->remove('dummy'));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldMergeCollections()
+    {
+        $array1 = ['foo' => 'bar'];
+        $array2 = ['dummy' => 'baz'];
+
+        $collection1 = new ArrayCollection($array1);
+        $collection2 = new ArrayCollection($array2);
+
+        $mergedCollection = $collection1->merge($collection2);
+
+        $this->assertEquals($array1+$array2, $mergedCollection->toArray());
+
+        $array1 = ['bar'];
+        $array2 = ['baz'];
+
+        $collection1 = new ArrayCollection($array1);
+        $collection2 = new ArrayCollection($array2);
+
+        $mergedCollection = $collection1->merge($collection2);
+
+        $this->assertEquals(array_merge($array1, $array2), $mergedCollection->toArray());
+    }
+}

--- a/tests/GeometryCollectionTest.php
+++ b/tests/GeometryCollectionTest.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace League\Geotools\Tests;
+
+use League\Geotools\Coordinate\Coordinate;
+use League\Geotools\Coordinate\CoordinateCollection;
+use League\Geotools\Coordinate\Ellipsoid;
+use League\Geotools\GeometryCollection;
+use League\Geotools\Polygon\Polygon;
+
+class GeometryCollectionTest extends TestCase
+{
+    private $firstGeometry;
+
+    private $secondGeometry;
+
+    public function setUp()
+    {
+        $this->firstGeometry = new Polygon(new CoordinateCollection([new Coordinate([1, 1])]));
+        $this->secondGeometry = new Polygon(new CoordinateCollection([new Coordinate([2, 2])]));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldHaveThePrecisionOfTheLessPreciseGeometryComponent()
+    {
+        $this->firstGeometry->setPrecision(5);
+        $this->secondGeometry->setPrecision(10);
+        $array = [$this->firstGeometry, $this->secondGeometry];
+
+        $collection = new SimpleGeometryCollection($array);
+
+        $this->assertEquals(10, $collection->getPrecision());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnNullIfItHasNoGeometry()
+    {
+        $collection = new SimpleGeometryCollection();
+
+        $this->assertNull($collection->getCoordinate());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnTheCoordinateOfItsFirstGeometry()
+    {
+        $array = [$this->firstGeometry, $this->secondGeometry];
+
+        $collection = new SimpleGeometryCollection($array);
+
+        $this->assertEquals(new Coordinate([1, 1]), $collection->getCoordinate());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnAnArrayOfAllTheCoordinatesOfItsGeometries()
+    {
+        $array = [$this->firstGeometry, $this->secondGeometry];
+
+        $collection = new SimpleGeometryCollection($array);
+
+        $this->assertEquals(
+            new CoordinateCollection([new Coordinate([1, 1]), new Coordinate([2, 2])]),
+            $collection->getCoordinates()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnTheMergedBoundingBoxOfAllItsGeometries()
+    {
+        $array = [$this->firstGeometry, $this->secondGeometry];
+
+        $collection = new SimpleGeometryCollection($array);
+
+        $this->assertEquals(
+            $this->firstGeometry->getBoundingBox()->merge($this->secondGeometry->getBoundingBox()),
+            $collection->getBoundingBox()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnTheEllipsoidOfItsFirstGeometry()
+    {
+        $array = [$this->firstGeometry];
+
+        $collection = new SimpleGeometryCollection($array);
+
+        $this->assertEquals($this->firstGeometry->getEllipsoid(), $collection->getEllipsoid());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldBehaveAsAnArrayOfGeometries()
+    {
+        $array = [$this->firstGeometry];
+
+        $collection = new SimpleGeometryCollection($array);
+
+        $this->assertEquals($this->firstGeometry, $collection[0]);
+        $this->assertFalse(isset($collection[99]));
+
+        $collection['test'] = $this->secondGeometry;
+        $this->assertEquals($this->secondGeometry, $collection['test']);
+
+        unset($collection['test']);
+        $this->assertFalse(isset($collection['test']));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldThrowAnExceptionWhenNotProvidedAGeometry()
+    {
+        $array = ['a'];
+
+        $this->setExpectedException('\InvalidArgumentException');
+
+        $collection = new SimpleGeometryCollection($array);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldThrowAnExceptionWhenProvidedAnInvalidGeometry()
+    {
+        $array = [$this->firstGeometry];
+
+        $collection = new SimpleGeometryCollection($array);
+
+        $secondGeometry = new Polygon(
+            new CoordinateCollection(
+                [
+                    new Coordinate(
+                        [2, 2],
+                        Ellipsoid::createFromName(Ellipsoid::AUSTRALIAN_NATIONAL)
+                    )
+                ]
+            )
+        );
+
+        $this->setExpectedException('\InvalidArgumentException');
+
+        $collection->add($secondGeometry);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldBeCountable()
+    {
+        $array = [$this->secondGeometry];
+
+        $collection = new SimpleGeometryCollection($array);
+
+        $this->assertEquals(1, count($collection));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldOfferAccessToInnerElementsByKey()
+    {
+        $array = ['foo' => $this->firstGeometry];
+
+        $collection = new SimpleGeometryCollection($array);
+        $this->assertEquals($this->firstGeometry, $collection->get('foo'));
+
+        $collection->set('dummy', $this->secondGeometry);
+        $this->assertEquals($this->secondGeometry, $collection->get('dummy'));
+        $this->assertNull($collection->get('bat'));
+
+        $collection->remove('dummy');
+        $this->assertNull($collection->get('dummy'));
+
+        $collection->add($this->secondGeometry);
+        $this->assertEquals($this->secondGeometry, $collection->get(0));
+
+        $this->assertNull($collection->remove('dummy'));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldMergeCollections()
+    {
+        $array1 = ['foo' => $this->firstGeometry];
+        $array2 = ['dummy' => $this->secondGeometry];
+
+        $collection1 = new SimpleGeometryCollection($array1);
+        $collection2 = new SimpleGeometryCollection($array2);
+
+        $mergedCollection = $collection1->merge($collection2);
+
+        $this->assertEquals($array1+$array2, $mergedCollection->toArray());
+
+        $array1 = [$this->firstGeometry];
+        $array2 = [$this->secondGeometry];
+
+        $collection1 = new SimpleGeometryCollection($array1);
+        $collection2 = new SimpleGeometryCollection($array2);
+
+        $mergedCollection = $collection1->merge($collection2);
+
+        $this->assertEquals(array_merge($array1, $array2), $mergedCollection->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldThorwAnExceptionWhenMergingDifferentTypesCollections()
+    {
+        $array1 = ['foo' => $this->firstGeometry];
+        $array2 = ['dummy' => $this->secondGeometry];
+
+        $collection1 = new SimpleGeometryCollection($array1);
+        $collection2 = new OtherGeometryCollection($array2);
+
+        $this->setExpectedException('\InvalidArgumentException');
+
+        $collection1->merge($collection2);
+    }
+}
+
+class SimpleGeometryCollection extends GeometryCollection
+{
+    public function getGeometryType()
+    {
+        return 'SIMPLE';
+    }
+}
+
+class OtherGeometryCollection extends GeometryCollection
+{
+    public function getGeometryType()
+    {
+        return 'OTHER';
+    }
+}

--- a/tests/Polygon/MultiPolygonTest.php
+++ b/tests/Polygon/MultiPolygonTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/*
+ * This file is part of the Geotools library.
+ *
+ * (c) Antoine Corcy <contact@sbin.dk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Geotools\Tests\Polygon;
+
+use League\Geotools\Coordinate\Coordinate;
+use League\Geotools\Polygon\MultiPolygon;
+use League\Geotools\Polygon\Polygon;
+
+/**
+ * @author Gabriel Bull <me@gabrielbull.com>
+ */
+class MultiPolygonTest extends \League\Geotools\Tests\TestCase
+{
+    /**
+     * @var Polygon
+     */
+    protected $polygon;
+
+    protected function setUp()
+    {
+        $this->polygon = new Polygon;
+    }
+
+    public function testType()
+    {
+        $multiPolygon = new MultiPolygon();
+
+        $this->assertEquals('MULTIPOLYGON', $multiPolygon->getGeometryType());
+    }
+
+    public function polygonAndVertexCoordinate()
+    {
+        return array(
+            array(
+                'polygonCoordinates' => array(
+                    array(48.9675969, 1.7440796),
+                    array(48.4711003, 2.5268555),
+                    array(48.9279131, 3.1448364),
+                    array(49.3895245, 2.6119995)
+                ),
+                'vertexCoordinate' => array(48.4711003, 2.5268555),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider polygonAndVertexCoordinate
+     * @param array $polygonCoordinates
+     * @param array $vertexCoordinate
+     */
+    public function testPointOnVertex($polygonCoordinates, $vertexCoordinate)
+    {
+        $this->polygon->set($polygonCoordinates);
+
+        $multiPolygon = new MultiPolygon([$this->polygon]);
+
+        $this->assertTrue($this->polygon->pointOnVertex(new Coordinate($vertexCoordinate)));
+        $this->assertTrue($multiPolygon->pointOnVertex(new Coordinate($vertexCoordinate)));
+    }
+
+    /**
+     * @dataProvider polygonAndVertexCoordinate
+     * @param array $polygonCoordinates
+     */
+    public function testPointNotOnVertex($polygonCoordinates)
+    {
+        $this->polygon->set($polygonCoordinates);
+
+        $multiPolygon = new MultiPolygon([$this->polygon]);
+
+        $this->assertFalse($this->polygon->pointOnVertex(new Coordinate(array(0, 0))));
+        $this->assertFalse($multiPolygon->pointOnVertex(new Coordinate(array(0, 0))));
+    }
+
+    public function polygonAndPointOnBoundaryCoordinate()
+    {
+        return array(
+            array(
+                'polygonCoordinates' => array(
+                    array(48.9675969, 1.7440796),
+                    array(48.4711003, 2.5268555),
+                    array(48.9279131, 3.1448364),
+                    array(49.3895245, 2.6119995)
+                ),
+                'pointOnBoundaryCoordinates' => array(
+                    array(48.7193486, 2.13546755),
+                    array(48.6995067, 2.83584595),
+                    array(49.1587188, 2.87841795),
+                    array(49.1785607, 2.17803955),
+                ),
+                'pointNotOnBoundaryCoordinates' => array(
+                    array(43.7193486, 2.13546755),
+                    array(45.6995067, 2.83584595),
+                    array(47.1587188, 2.87841795),
+                    array(20.1785607, 2.17803955),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider polygonAndPointOnBoundaryCoordinate
+     * @param array $polygonCoordinates
+     * @param array $pointOnBoundaryCoordinates
+     */
+    public function testPointOnBoundary($polygonCoordinates, $pointOnBoundaryCoordinates)
+    {
+        $this->polygon->set($polygonCoordinates);
+
+        $multiPolygon = new MultiPolygon([$this->polygon]);
+
+        foreach ($pointOnBoundaryCoordinates as $pointOnBoundaryCoordinate) {
+            $this->assertTrue($this->polygon->pointOnBoundary(new Coordinate($pointOnBoundaryCoordinate)));
+            $this->assertTrue($multiPolygon->pointOnBoundary(new Coordinate($pointOnBoundaryCoordinate)));
+        }
+    }
+
+    /**
+     * @dataProvider polygonAndPointOnBoundaryCoordinate
+     * @param array $polygonCoordinates
+     * @param array $pointOnBoundaryCoordinates
+     * @param array $pointNotOnBoundaryCoordinates
+     */
+    public function testPointNotOnBoundary(
+        $polygonCoordinates,
+        $pointOnBoundaryCoordinates,
+        $pointNotOnBoundaryCoordinates
+    ) {
+        $this->polygon->set($polygonCoordinates);
+
+        $multiPolygon = new MultiPolygon([$this->polygon]);
+
+        foreach ($pointNotOnBoundaryCoordinates as $pointNotOnBoundaryCoordinate) {
+            $this->assertFalse($this->polygon->pointOnBoundary(new Coordinate($pointNotOnBoundaryCoordinate)));
+            $this->assertFalse($multiPolygon->pointOnBoundary(new Coordinate($pointNotOnBoundaryCoordinate)));
+        }
+    }
+
+    public function polygonAndPointInPolygonCoordinate()
+    {
+        return array(
+            array(
+                'polygonCoordinates' => array(
+                    array(48.9675969, 1.7440796),
+                    array(48.4711003, 2.5268555),
+                    array(48.9279131, 3.1448364),
+                    array(49.3895245, 2.6119995)
+                ),
+                'pointInPolygonCoordinates' => array(
+                    array(49.1785607, 2.4444580),
+                    array(49.1785607, 2.0000000),
+                    array(49.1785607, 1.7440796),
+                    array(48.9279131, 2.4444580),
+                ),
+                'pointNotInPolygonCoordinates' => array(
+                    array(49.1785607, 5),
+                    array(50, 2.4444580),
+                )
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider polygonAndPointInPolygonCoordinate
+     * @param array $polygonCoordinates
+     * @param array $pointInPolygonCoordinates
+     */
+    public function testPointInPolygon($polygonCoordinates, $pointInPolygonCoordinates)
+    {
+        $this->polygon->set($polygonCoordinates);
+
+        $multiPolygon = new MultiPolygon([$this->polygon]);
+
+        foreach ($pointInPolygonCoordinates as $pointInPolygonCoordinate) {
+            $this->assertTrue($this->polygon->pointInPolygon(new Coordinate($pointInPolygonCoordinate)));
+            $this->assertTrue($multiPolygon->pointInPolygon(new Coordinate($pointInPolygonCoordinate)));
+        }
+    }
+
+    /**
+     * @dataProvider polygonAndPointInPolygonCoordinate
+     * @param array $polygonCoordinates
+     * @param array $pointInPolygonCoordinates
+     * @param array $pointNotInPolygonCoordinates
+     */
+    public function testPointNotInPolygon(
+        $polygonCoordinates,
+        $pointInPolygonCoordinates,
+        $pointNotInPolygonCoordinates
+    ) {
+        $this->polygon->set($polygonCoordinates);
+
+        $multiPolygon = new MultiPolygon([$this->polygon]);
+
+        foreach ($pointNotInPolygonCoordinates as $pointNotInPolygonCoordinate) {
+            $this->assertFalse($this->polygon->pointInPolygon(new Coordinate($pointNotInPolygonCoordinate)));
+            $this->assertFalse($multiPolygon->pointInPolygon(new Coordinate($pointNotInPolygonCoordinate)));
+        }
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,7 +20,7 @@ use League\Geotools\Coordinate\Ellipsoid;
 /**
  * @author Antoine Corcy <contact@sbin.dk>
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
     /**
      * @return GeocoderInterface


### PR DESCRIPTION
Following issue [#81](https://github.com/thephpleague/geotools/issues/81), I propose to you the first new Geometries.

There are some BC changes, but I think it's for the best.

I changed the `PolygonInterface` to extract the really useful methods from the outside, not the ones only used to construct the objects. I do believe geometries should be made immutable in a near future.
I created the `GeometryInterface` and made `PolygonInterface` extend it
I created the `GeometryCollection` class extending the `ArrayCollection` and only accepting `Geometries`
I created the `MultiPolygon` class implementing the `PolygonInterface` and extending the `GeometryCollection`.
I changed some behavior on existing classes (`BoundingBox`, `CoordinateCollection`, etc.), mainly, to add features or to ensure better consistency.

Tests have been added for the new classes and some for the old ones.

Tell me what you think of it.
