### PR TITLE
Updated namespace to providers

### DIFF
--- a/src/CLI/Command/Geocoder/Command.php
+++ b/src/CLI/Command/Geocoder/Command.php
@@ -163,7 +163,7 @@ class Command extends \Symfony\Component\Console\Command\Command
             ? $this->providers[$provider]
             : $this->providers['google_maps'];
 
-        return '\\Geocoder\\Provider\\' . $provider;
+        return '\\Geocoder\\Provider\\' . $provider . $provider;
     }
 
     /**


### PR DESCRIPTION
Since 4.0 of the Geocoder library, all providers has a new namespace