### PR TITLE
Fix deserialization of coordinates in BatchGeocoded::fromArray 

### DIFF
--- a/src/Batch/BatchGeocoded.php
+++ b/src/Batch/BatchGeocoded.php
@@ -189,6 +189,10 @@ class BatchGeocoded
             $this->exception = $data['exception'];
         }
 
+        //GeoCoder Address::createFromArray expects longitude/latitude keys
+        $data['address']['longitude'] = $data['address']['coordinates']['longitude'] ?? null;
+        $data['address']['latitude'] = $data['address']['coordinates']['latitude'] ?? null;
+
         // Shortcut to create the address and set it in this class
         $this->setAddress(Address::createFromArray($data['address']));
     }

--- a/tests/Batch/BatchGeocodedTest.php
+++ b/tests/Batch/BatchGeocodedTest.php
@@ -11,6 +11,7 @@
 
 namespace League\Geotools\Tests\Batch;
 
+use Geocoder\Model\Coordinates;
 use League\Geotools\Batch\BatchGeocoded;
 
 /**
@@ -65,4 +66,97 @@ class BatchGeocodedTest extends \League\Geotools\Tests\TestCase
         $this->assertInstanceOf('\Geocoder\Model\Country', $address->getCountry());
         $this->assertInstanceOf('\Geocoder\Model\AdminLevelCollection', $address->getAdminLevels());
 	}
+
+    public function testFromArrayWithRealData()
+    {
+        $array = array(
+            'providerName'     => 'chain',
+            'query'            => 'Julianaplein 1 , Noord-Holland, Amsterdam, Nederland',
+            'exceptionMessage' => '',
+            'address'          =>
+                array(
+                    'id'                => 'ChIJPd2JhH8JxkcRQ8jSHUchci0',
+                    'locationType'      => 'ROOFTOP',
+                    'resultType'        =>
+                        array(
+                            0 => 'premise',
+                        ),
+                    'formattedAddress'  => 'Amstelstation, Julianaplein 1, 1097 DN Amsterdam, Netherlands',
+                    'airport'           => null,
+                    'colloquialArea'    => null,
+                    'intersection'      => null,
+                    'naturalFeature'    => null,
+                    'neighborhood'      => null,
+                    'park'              => null,
+                    'pointOfInterest'   => null,
+                    'political'         => 'Netherlands',
+                    'premise'           => 'Amstelstation',
+                    'streetAddress'     => null,
+                    'subpremise'        => null,
+                    'ward'              => null,
+                    'establishment'     => null,
+                    'subLocalityLevels' =>
+                        array(
+                            1 =>
+                                array(
+                                    'level' => 1,
+                                    'name'  => 'Amsterdam-Oost',
+                                    'code'  => 'Amsterdam-Oost',
+                                ),
+                        ),
+                    'providedBy'        => 'google_maps',
+                    'coordinates'       =>
+                        array(
+                            'latitude'  => 52.346483799999987,
+                            'longitude' => 4.9176187999999996,
+                        ),
+                    'bounds'            =>
+                        array(
+                            'south' => 52.345422000000013,
+                            'west'  => 4.9166017000000002,
+                            'north' => 52.347514699999998,
+                            'east'  => 4.9187972000000002,
+                        ),
+                    'streetNumber'      => '1',
+                    'streetName'        => 'Julianaplein',
+                    'locality'          => 'Amsterdam',
+                    'postalCode'        => '1097 DN',
+                    'subLocality'       => 'Amsterdam-Oost',
+                    'adminLevels'       =>
+                        array(
+                            1 =>
+                                array(
+                                    'level' => 1,
+                                    'name'  => 'Noord-Holland',
+                                    'code'  => 'NH',
+                                ),
+                            2 =>
+                                array(
+                                    'level' => 2,
+                                    'name'  => 'Amsterdam',
+                                    'code'  => 'Amsterdam',
+                                ),
+                        ),
+                    'country'           => 'Netherlands',
+                    'timezone'          => null,
+                ),
+            'coordinates'      =>
+                array(
+                    'latitude'  => 52.346483799999987,
+                    'longitude' => 4.9176187999999996,
+                ),
+            'latitude'         => 52.346483799999987,
+            'longitude'        => 4.9176187999999996,
+        );
+
+        $this->batchGeocoded->fromArray($array);
+
+        $this->assertEquals('chain', $this->batchGeocoded->getProviderName());
+        $this->assertEquals('Julianaplein 1 , Noord-Holland, Amsterdam, Nederland', $this->batchGeocoded->getQuery());
+        $this->assertEquals('', $this->batchGeocoded->getExceptionMessage());
+        $this->assertInstanceOf('\Geocoder\Model\Address', $this->batchGeocoded->getAddress());
+        $this->assertEquals(new Coordinates(52.346483799999987, 4.9176187999999996), $this->batchGeocoded->getCoordinates());
+        $this->assertEquals(52.346483799999987, $this->batchGeocoded->getLatitude());
+        $this->assertEquals(4.9176187999999996, $this->batchGeocoded->getLongitude());
+    }
 }


### PR DESCRIPTION
I found a bug where (when loading a geocode result from the cache) BatchGeocoded::fromArray left the coordinates null. I added a testcase using a real result I have in my cache.