### PR TITLE
Fix namespace issue when creating provider class name

### DIFF
--- a/src/CLI/Command/Geocoder/Command.php
+++ b/src/CLI/Command/Geocoder/Command.php
@@ -101,7 +101,7 @@ class Command extends \Symfony\Component\Console\Command\Command
             ? $this->providers[$provider]
             : $this->providers['google_maps'];
 
-        return '\\Geocoder\\Provider\\' . $provider . $provider;
+        return '\\Geocoder\\Provider\\' . $provider . '\\' . $provider;
     }
 
     /**


### PR DESCRIPTION
Currently, running

`./vendor/bin/geotools geocoder:geocode "74.200.247.59" --provider="google_maps"`
produces following error 
`PHP Fatal error:  Uncaught Error: Class '\Geocoder\Provider\GoogleMapsGoogleMaps' not found`

This PR fixes the generation of provider class name.