### PR TITLE
Remove length' argument's default value from 'encode' method

### DIFF
--- a/src/Geohash/GeohashInterface.php
+++ b/src/Geohash/GeohashInterface.php
@@ -30,7 +30,7 @@ interface GeohashInterface
      *
      * @throws InvalidArgumentException
      */
-    public function encode(CoordinateInterface $coordinate, $length = self::MAX_LENGTH);
+    public function encode(CoordinateInterface $coordinate, $length);
 
     /**
      * Returns the decoded geo hash to it's center.


### PR DESCRIPTION
`MAX_LENGHT` constant is not defined in `GeohashInterface` interface, but it is defined in `Geohash` class which implements it.

The constants `MIN_LENGTH` and `MAX_LENGHT` could be moved to the `GeohashInterface`, but I think it makes more sense to leave it for the implementing class `Geohash` to define the defaults since it also does the length min/max validation.