### PR TITLE
Upgrade to PHP >= 7.3 and PHPUnit 8.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: false
+
 cache:
     directories:
         - $HOME/.composer/cache/files
@@ -13,27 +13,35 @@ matrix:
     fast_finish: true
     include:
           # Minimum supported dependencies with the latest and oldest PHP version
-        - php: 7.2
+        - php: 7.3
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
-        - php: 7.0
+        - php: 7.4
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
 
           # Test the latest stable release
-        - php: 7.0
-        - php: 7.1
-        - php: 7.2
+        - php: 7.3
+          env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
+        - php: 7.4
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
 
-        - php: 7.2
-          env: SYMFONY_REQUIRE="~2.8"
-        - php: 7.2
+        - php: 7.3
           env: SYMFONY_REQUIRE="~3.4"
-        - php: 7.2
+        - php: 7.3
           env: SYMFONY_REQUIRE="~4.4"
-        - php: 7.2
+        - php: 7.3
           env: SYMFONY_REQUIRE="~5.0"
+
+        - php: 7.4
+          env: SYMFONY_REQUIRE="~3.4"
+        - php: 7.4
+          env: SYMFONY_REQUIRE="~4.4"
+        - php: 7.4
+          env: SYMFONY_REQUIRE="~5.0"
+
           # Latest commit to master
-        - php: 7.2
+        - php: 7.3
+          env: STABILITY="dev"
+        - php: 7.4
           env: STABILITY="dev"
 
     allow_failures:
@@ -46,8 +54,6 @@ before_install:
     - if [ "$SYMFONY_REQUIRE" != "" ]; then composer global require --no-scripts symfony/flex; fi
 
 install:
-    # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
-    - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
     - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
 
     "require-dev" : {
-        "phpunit/phpunit"         : "^7.0"
+        "phpunit/phpunit"         : "^8.5"
     },
 
     "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name"        : "league/geotools",
     "type"        : "library",
-    "description" : "Geo-related tools PHP 7.0+ library",
+    "description" : "Geo-related tools PHP 7.3+ library",
     "keywords"    : ["geotools", "geometry", "geocoder", "geocoding", "geoip", "bounds", "distance", "batch", "async", "geohash", "geolocation", "latlong", "latitude", "longitude"],
     "license"     : "MIT",
 
@@ -22,13 +22,13 @@
     },
 
     "require" : {
-        "php"                     : "^7.0",
+        "php"                     : "^7.3 || ^7.4",
         "psr/cache"               : "^1.0",
         "willdurand/geocoder"     : "^4.2",
         "react/promise"           : "^2.2",
-        "symfony/console"         : "^2.7 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/property-access" : "^2.7 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/serializer"      : "^2.7 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/console"         : "^3.4 || ^4.4 || ^5.0",
+        "symfony/property-access" : "^3.4 || ^4.4 || ^5.0",
+        "symfony/serializer"      : "^3.4 || ^4.4 || ^5.0",
         "react/event-loop"        : "0.4.*",
         "php-http/discovery"      : "^1.0",
         "cache/array-adapter"     : "^1.0",
@@ -36,7 +36,7 @@
     },
 
     "require-dev" : {
-        "phpunit/phpunit"         : "^6.5.5 || ^7.0"
+        "phpunit/phpunit"         : "^7.0"
     },
 
     "autoload" : {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="tests/bootstrap.php"
     >
     <testsuites>

--- a/tests/Batch/BatchGeocodedTest.php
+++ b/tests/Batch/BatchGeocodedTest.php
@@ -24,7 +24,7 @@ class BatchGeocodedTest extends \League\Geotools\Tests\TestCase
 	 */
 	protected $batchGeocoded;
 
-	protected function setUp()
+	protected function setup(): void
 	{
 		$this->batchGeocoded = new BatchGeocoded;
 	}

--- a/tests/Batch/BatchTest.php
+++ b/tests/Batch/BatchTest.php
@@ -32,7 +32,7 @@ class BatchTest extends \League\Geotools\Tests\TestCase
     protected $values;
     protected $coordinates;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->data = array(
             'latitude'  => 48.8234055,

--- a/tests/BoundingBox/BoundingBoxTest.php
+++ b/tests/BoundingBox/BoundingBoxTest.php
@@ -27,7 +27,7 @@ class BoundingBoxTest extends \League\Geotools\Tests\TestCase
      */
     protected $polygon;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->polygon = new Polygon;
     }

--- a/tests/CLI/Command/Convert/DMSTest.php
+++ b/tests/CLI/Command/Convert/DMSTest.php
@@ -24,7 +24,7 @@ class DMSTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new DMS);

--- a/tests/CLI/Command/Convert/DMTest.php
+++ b/tests/CLI/Command/Convert/DMTest.php
@@ -24,7 +24,7 @@ class DMTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new DM);

--- a/tests/CLI/Command/Convert/UTMTest.php
+++ b/tests/CLI/Command/Convert/UTMTest.php
@@ -24,7 +24,7 @@ class UTMTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new UTM);

--- a/tests/CLI/Command/Distance/AllTest.php
+++ b/tests/CLI/Command/Distance/AllTest.php
@@ -24,7 +24,7 @@ class AllTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new All);

--- a/tests/CLI/Command/Distance/FlatTest.php
+++ b/tests/CLI/Command/Distance/FlatTest.php
@@ -24,7 +24,7 @@ class FlatTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new Flat);

--- a/tests/CLI/Command/Distance/GreatCircleTest.php
+++ b/tests/CLI/Command/Distance/GreatCircleTest.php
@@ -24,7 +24,7 @@ class GreatCircleTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new GreatCircle);

--- a/tests/CLI/Command/Distance/HaversineTest.php
+++ b/tests/CLI/Command/Distance/HaversineTest.php
@@ -24,7 +24,7 @@ class HaversineTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new Haversine);

--- a/tests/CLI/Command/Distance/VincentyTest.php
+++ b/tests/CLI/Command/Distance/VincentyTest.php
@@ -24,7 +24,7 @@ class VincentyTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new Vincenty);

--- a/tests/CLI/Command/Geocoder/GeocodeTest.php
+++ b/tests/CLI/Command/Geocoder/GeocodeTest.php
@@ -24,7 +24,7 @@ class GeocodeTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new Geocode);

--- a/tests/CLI/Command/Geocoder/ReverseTest.php
+++ b/tests/CLI/Command/Geocoder/ReverseTest.php
@@ -24,7 +24,7 @@ class ReverseTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new Reverse);

--- a/tests/CLI/Command/Geohash/DecodeTest.php
+++ b/tests/CLI/Command/Geohash/DecodeTest.php
@@ -24,7 +24,7 @@ class DecodeTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new Decode);

--- a/tests/CLI/Command/Geohash/EncodeTest.php
+++ b/tests/CLI/Command/Geohash/EncodeTest.php
@@ -25,7 +25,7 @@ class EncodeTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new Encode);

--- a/tests/CLI/Command/Vertex/DestinationTest.php
+++ b/tests/CLI/Command/Vertex/DestinationTest.php
@@ -24,7 +24,7 @@ class DestinationTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new Destination);

--- a/tests/CLI/Command/Vertex/FinalBearingTest.php
+++ b/tests/CLI/Command/Vertex/FinalBearingTest.php
@@ -24,7 +24,7 @@ class FinalBearingTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new FinalBearing);

--- a/tests/CLI/Command/Vertex/FinalCardinalTest.php
+++ b/tests/CLI/Command/Vertex/FinalCardinalTest.php
@@ -24,7 +24,7 @@ class FinalCardinalTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new FinalCardinal);

--- a/tests/CLI/Command/Vertex/InitialBearingTest.php
+++ b/tests/CLI/Command/Vertex/InitialBearingTest.php
@@ -24,7 +24,7 @@ class InitialBearingTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new InitialBearing);

--- a/tests/CLI/Command/Vertex/InitialCardinalTest.php
+++ b/tests/CLI/Command/Vertex/InitialCardinalTest.php
@@ -24,7 +24,7 @@ class InitialCardinalTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new InitialCardinal);

--- a/tests/CLI/Command/Vertex/MiddleTest.php
+++ b/tests/CLI/Command/Vertex/MiddleTest.php
@@ -24,7 +24,7 @@ class MiddleTest extends \League\Geotools\Tests\TestCase
     protected $command;
     protected $commandTester;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->application = new Application;
         $this->application->add(new Middle);

--- a/tests/CoordinateCoupleTest.php
+++ b/tests/CoordinateCoupleTest.php
@@ -20,7 +20,7 @@ class CoordinateCoupeTest extends TestCase
 {
     protected $geotools;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->geotools = new MockCoordinateCouple;
     }

--- a/tests/Distance/DistanceTest.php
+++ b/tests/Distance/DistanceTest.php
@@ -25,7 +25,7 @@ class DistanceTest extends \League\Geotools\Tests\TestCase
     protected $coordA;
     protected $coordB;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->distance = new TestableDistance;
         $this->from     = $this->getStubCoordinate();

--- a/tests/Geohash/GeohashTest.php
+++ b/tests/Geohash/GeohashTest.php
@@ -20,7 +20,7 @@ class GeohashTest extends \League\Geotools\Tests\TestCase
 {
     protected $geohash;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->geohash = new Geohash;
     }

--- a/tests/GeometryCollectionTest.php
+++ b/tests/GeometryCollectionTest.php
@@ -14,7 +14,7 @@ class GeometryCollectionTest extends TestCase
 
     private $secondGeometry;
 
-    public function setUp()
+    public function setup(): void
     {
         $this->firstGeometry = new Polygon(new CoordinateCollection([new Coordinate([1, 1])]));
         $this->secondGeometry = new Polygon(new CoordinateCollection([new Coordinate([2, 2])]));

--- a/tests/GeotoolsTest.php
+++ b/tests/GeotoolsTest.php
@@ -22,7 +22,7 @@ class GeotoolsTest extends TestCase
 {
     protected $geotools;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->geotools = new Geotools();
     }

--- a/tests/Polygon/MultiPolygonTest.php
+++ b/tests/Polygon/MultiPolygonTest.php
@@ -25,7 +25,7 @@ class MultiPolygonTest extends \League\Geotools\Tests\TestCase
      */
     protected $polygon;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->polygon = new Polygon;
     }

--- a/tests/Polygon/PolygonTest.php
+++ b/tests/Polygon/PolygonTest.php
@@ -24,7 +24,7 @@ class PolygonTest extends \League\Geotools\Tests\TestCase
      */
     protected $polygon;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->polygon = new Polygon;
     }

--- a/tests/Vertex/VertexTest.php
+++ b/tests/Vertex/VertexTest.php
@@ -24,7 +24,7 @@ class VertexTest extends \League\Geotools\Tests\TestCase
     protected $from;
     protected $to;
 
-    protected function setUp()
+    protected function setup(): void
     {
         $this->vertex = new Vertex;
         $this->from  = $this->getStubCoordinate();


### PR DESCRIPTION
Hello,

Here is an upgrade of geotools and a new format of coordinates frequently used.

Please review this PR. I'd like to use it without create my own fork.
Maybe you can release as `1.0.0` (It's a breaking change I think) 