### PR TITLE
Fix PHPUnit deprecations

### DIFF
--- a/tests/Batch/BatchTest.php
+++ b/tests/Batch/BatchTest.php
@@ -67,6 +67,9 @@ class BatchTest extends \League\Geotools\Tests\TestCase
         $this->geocoder = $this->getMockGeocoderReturns($this->providers);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testConstructorShouldAcceptGeocoderInterface()
     {
         new TestableBatch($this->getStubGeocoder());
@@ -113,12 +116,12 @@ class BatchTest extends \League\Geotools\Tests\TestCase
     }
 
     /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The argument should be a string or an array of strings to geocode.
      * @dataProvider invalidValuesProvider
      */
     public function testGeocodeShouldThrowInvalidArgumentException($values)
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The argument should be a string or an array of strings to geocode.');
         $batch = new TestableBatch($this->geocoder);
         $batch->geocode($values);
     }
@@ -168,12 +171,12 @@ class BatchTest extends \League\Geotools\Tests\TestCase
     }
 
     /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The argument should be a Coordinate instance or an array of Coordinate instances to reverse.
      * @dataProvider coordinatesProvider
      */
     public function testReverseShouldThrowInvalidArgumentException($coordinates)
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The argument should be a Coordinate instance or an array of Coordinate instances to reverse.');
         $batch = new TestableBatch($this->geocoder);
         $batch->reverse($coordinates);
     }
@@ -735,12 +738,10 @@ class BatchTest extends \League\Geotools\Tests\TestCase
         }
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage booooooooooo!
-     */
     public function testSeriesShouldThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('booooooooooo!');
         $batch = new TestableBatch($this->geocoder);
         $batch->setTasks($tasks = array(
             function () {
@@ -755,12 +756,10 @@ class BatchTest extends \League\Geotools\Tests\TestCase
         ))->geocode('foo')->serie();
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage booooooooooo!
-     */
     public function testParallelShouldThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('booooooooooo!');
         $called = 0;
 
         $batch = new TestableBatch($this->geocoder);

--- a/tests/BoundingBox/BoundingBoxTest.php
+++ b/tests/BoundingBox/BoundingBoxTest.php
@@ -50,27 +50,34 @@ class BoundingBoxTest extends \League\Geotools\Tests\TestCase
         );
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testConstructWithPolygon()
     {
         new BoundingBox(new Polygon);
     }
 
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testConstructWithCoordinate()
     {
         new BoundingBox(new Coordinate(array(0, 0)));
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testConstructWithNull()
     {
         new BoundingBox;
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructWithInvalidArgument()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new BoundingBox('string');
     }
 

--- a/tests/CLI/Command/Convert/DMSTest.php
+++ b/tests/CLI/Command/Convert/DMSTest.php
@@ -34,23 +34,19 @@ class DMSTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'    => $this->command->getName(),
             'coordinate' => 'foo, bar',
@@ -93,12 +89,10 @@ class DMSTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/<value> <\/value>/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'coordinate'  => '40° 26.7717, -79° 56.93172',
@@ -106,12 +100,10 @@ class DMSTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'coordinate'  => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Convert/DMTest.php
+++ b/tests/CLI/Command/Convert/DMTest.php
@@ -34,23 +34,19 @@ class DMTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'    => $this->command->getName(),
             'coordinate' => 'foo, bar',
@@ -93,12 +89,10 @@ class DMTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/<value> <\/value>/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'coordinate'  => '40° 26.7717, -79° 56.93172',
@@ -106,12 +100,10 @@ class DMTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'coordinate'  => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Convert/UTMTest.php
+++ b/tests/CLI/Command/Convert/UTMTest.php
@@ -34,23 +34,19 @@ class UTMTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'    => $this->command->getName(),
             'coordinate' => 'foo, bar',
@@ -68,12 +64,10 @@ class UTMTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/31U 449152 5408055/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'coordinate'  => '40° 26.7717, -79° 56.93172',
@@ -81,12 +75,10 @@ class UTMTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'coordinate'  => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Distance/AllTest.php
+++ b/tests/CLI/Command/Distance/AllTest.php
@@ -34,23 +34,19 @@ class AllTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -136,12 +132,10 @@ EOF;
         $this->assertSame($expected, $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -150,12 +144,10 @@ EOF;
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Distance/FlatTest.php
+++ b/tests/CLI/Command/Distance/FlatTest.php
@@ -34,23 +34,19 @@ class FlatTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -109,12 +105,10 @@ class FlatTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/15387805\.348722/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -123,12 +117,10 @@ class FlatTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Distance/GreatCircleTest.php
+++ b/tests/CLI/Command/Distance/GreatCircleTest.php
@@ -34,23 +34,19 @@ class GreatCircleTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -109,12 +105,10 @@ class GreatCircleTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/15176576\.404156/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -123,12 +117,10 @@ class GreatCircleTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Distance/HaversineTest.php
+++ b/tests/CLI/Command/Distance/HaversineTest.php
@@ -34,23 +34,19 @@ class HaversineTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -109,12 +105,10 @@ class HaversineTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/15176576\.404156/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -123,12 +117,10 @@ class HaversineTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Distance/VincentyTest.php
+++ b/tests/CLI/Command/Distance/VincentyTest.php
@@ -34,23 +34,19 @@ class VincentyTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -109,12 +105,10 @@ class VincentyTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/15189497\.36786/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -123,12 +117,10 @@ class VincentyTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Geocoder/GeocodeTest.php
+++ b/tests/CLI/Command/Geocoder/GeocodeTest.php
@@ -34,12 +34,10 @@ class GeocodeTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));

--- a/tests/CLI/Command/Geocoder/ReverseTest.php
+++ b/tests/CLI/Command/Geocoder/ReverseTest.php
@@ -34,23 +34,19 @@ class ReverseTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'    => $this->command->getName(),
             'coordinate' => 'foo, bar',

--- a/tests/CLI/Command/Geohash/DecodeTest.php
+++ b/tests/CLI/Command/Geohash/DecodeTest.php
@@ -34,23 +34,19 @@ class DecodeTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\RuntimeException
-     * @expectedExceptionMessage This geo hash is invalid.
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('This geo hash is invalid.');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
             'geohash' => 'foo, bar',

--- a/tests/CLI/Command/Geohash/EncodeTest.php
+++ b/tests/CLI/Command/Geohash/EncodeTest.php
@@ -35,23 +35,19 @@ class EncodeTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'    => $this->command->getName(),
             'coordinate' => 'foo, bar',
@@ -70,12 +66,10 @@ class EncodeTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/u09tu800gnqw/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The length should be between 1 and 12.
-     */
     public function testExecuteInvalidLengthOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The length should be between 1 and 12.');
         $this->commandTester->execute(array(
             'command'    => $this->command->getName(),
             'coordinate' => '48.8234055, 2.3072664',
@@ -95,12 +89,10 @@ class EncodeTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/<value>dppn<\/value>/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The length should be between 1 and 12.
-     */
     public function testExecuteWithEmptyLengthOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The length should be between 1 and 12.');
         $this->commandTester->execute(array(
             'command'    => $this->command->getName(),
             'coordinate' => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Vertex/DestinationTest.php
+++ b/tests/CLI/Command/Vertex/DestinationTest.php
@@ -34,23 +34,19 @@ class DestinationTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'  => $this->command->getName(),
             'origin'   => 'foo, bar',
@@ -72,12 +68,10 @@ class DestinationTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/47\.026774650075, 2\.3072664/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '48.8234055, 2.3072664',
@@ -87,12 +81,10 @@ class DestinationTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '48.8234055, 2.3072664',

--- a/tests/CLI/Command/Vertex/FinalBearingTest.php
+++ b/tests/CLI/Command/Vertex/FinalBearingTest.php
@@ -34,23 +34,19 @@ class FinalBearingTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -70,12 +66,10 @@ class FinalBearingTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/118/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -84,12 +78,10 @@ class FinalBearingTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Vertex/FinalCardinalTest.php
+++ b/tests/CLI/Command/Vertex/FinalCardinalTest.php
@@ -34,23 +34,19 @@ class FinalCardinalTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -70,12 +66,10 @@ class FinalCardinalTest extends \League\Geotools\Tests\TestCase
         $this->assertSame('<value>ESE</value>', trim($this->commandTester->getDisplay()));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -84,12 +78,10 @@ class FinalCardinalTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Vertex/InitialBearingTest.php
+++ b/tests/CLI/Command/Vertex/InitialBearingTest.php
@@ -34,23 +34,19 @@ class InitialBearingTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -70,12 +66,10 @@ class InitialBearingTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/87/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -84,12 +78,10 @@ class InitialBearingTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Vertex/InitialCardinalTest.php
+++ b/tests/CLI/Command/Vertex/InitialCardinalTest.php
@@ -34,23 +34,19 @@ class InitialCardinalTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -70,12 +66,10 @@ class InitialCardinalTest extends \League\Geotools\Tests\TestCase
         $this->assertSame('<value>E</value>', trim($this->commandTester->getDisplay()));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -84,12 +78,10 @@ class InitialCardinalTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/CLI/Command/Vertex/MiddleTest.php
+++ b/tests/CLI/Command/Vertex/MiddleTest.php
@@ -34,23 +34,19 @@ class MiddleTest extends \League\Geotools\Tests\TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testExecuteWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
         $this->commandTester->execute(array(
             'command' => $this->command->getName(),
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testExecuteInvalidArguments()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => 'foo, bar',
@@ -70,12 +66,10 @@ class MiddleTest extends \League\Geotools\Tests\TestCase
         $this->assertRegExp('/38\.068139209793, -53\.187718854545/', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testExecuteWithEmptyEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',
@@ -84,12 +78,10 @@ class MiddleTest extends \League\Geotools\Tests\TestCase
         ));
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testExecuteWithoutAvailableEllipsoidOption()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         $this->commandTester->execute(array(
             'command'     => $this->command->getName(),
             'origin'      => '40° 26.7717, -79° 56.93172',

--- a/tests/Convert/ConvertTest.php
+++ b/tests/Convert/ConvertTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace League\Geotools\Tests;
+namespace League\Geotools\Tests\Convert;
 
 use League\Geotools\Convert\Convert;
 use League\Geotools\Coordinate\Coordinate;
@@ -19,6 +19,9 @@ use League\Geotools\Coordinate\Coordinate;
 */
 class ConvertTest extends \League\Geotools\Tests\TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testConstructorShouldAcceptCoordinateInterface()
     {
         new TestableConvert($this->getStubCoordinate());

--- a/tests/Coordinate/CoordinateTest.php
+++ b/tests/Coordinate/CoordinateTest.php
@@ -20,12 +20,12 @@ use League\Geotools\Coordinate\Ellipsoid;
 class CoordinateTest extends \League\Geotools\Tests\TestCase
 {
     /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a string, an array or a class which implements Geocoder\Model\Address !
      * @dataProvider invalidCoordinatesProvider
      */
     public function testConstructorWithInvalidCoordinatesShouldThrowAnException($coordinates)
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a string, an array or a class which implements Geocoder\Model\Address !');
         new Coordinate($coordinates);
     }
 
@@ -45,12 +45,12 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
     }
 
     /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
      * @dataProvider invalidStringCoordinatesProvider
      */
     public function testConstructorWithInvalidStringCoordinatesShouldThrowAnException($coordinates)
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         new Coordinate($coordinates);
     }
 
@@ -167,6 +167,9 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
         );
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testConstructorWithAddressArgumentShouldBeValid()
     {
         new Coordinate($this->createEmptyAddress());
@@ -318,22 +321,18 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
         $this->assertInstanceOf('League\Geotools\Coordinate\Ellipsoid', $ellipsoid);
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The given coordinates should be a string !
-     */
     public function testCreateFromStringWithoutAString()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given coordinates should be a string !');
         $coordinate = new Coordinate($this->createEmptyAddress());
         $coordinate->setFromString(123);
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage It should be a valid and acceptable ways to write geographic coordinates !
-     */
     public function testCreateFromStringWithInvalidCoordinateString()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('It should be a valid and acceptable ways to write geographic coordinates !');
         $coordinate = new Coordinate($this->createEmptyAddress());
         $coordinate->setFromString('foo');
     }

--- a/tests/Coordinate/EllipsoidTest.php
+++ b/tests/Coordinate/EllipsoidTest.php
@@ -19,12 +19,12 @@ use League\Geotools\Coordinate\Ellipsoid;
 class EllipsoidTest extends \League\Geotools\Tests\TestCase
 {
     /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The inverse flattening cannot be negative or equal to zero !
      * @dataProvider constructorArgumentsWhichThrowException
      */
     public function testConstructWithInverseFlatteningEqualsToZero($invF)
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The inverse flattening cannot be negative or equal to zero !');
         new Ellipsoid('foo', 'bar', $invF);
     }
 
@@ -65,21 +65,17 @@ class EllipsoidTest extends \League\Geotools\Tests\TestCase
         );
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage foo ellipsoid does not exist in selected reference ellipsoids !
-     */
     public function testCreateFromNameUnavailableEllipsoidThrowsException()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo ellipsoid does not exist in selected reference ellipsoids !');
         Ellipsoid::createFromName('foo');
     }
 
-    /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Please provide an ellipsoid name !
-     */
     public function testCreateFromNameEmptyNameThrowsException()
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide an ellipsoid name !');
         Ellipsoid::createFromName(' ');
     }
 
@@ -91,18 +87,18 @@ class EllipsoidTest extends \League\Geotools\Tests\TestCase
         $this->assertInstanceOf('League\Geotools\Coordinate\Ellipsoid', $ellipsoid);
         $this->assertSame('WGS 84', $ellipsoid->getName());
         $this->assertSame(6378136.0, $ellipsoid->getA());
-        $this->assertEquals(6356751.317598, $ellipsoid->getB(), '', 0.0001);
+        $this->assertEqualsWithDelta(6356751.317598, $ellipsoid->getB(), 0.0001, '');
         $this->assertSame(298.257223563, $ellipsoid->getInvF());
-        $this->assertEquals(6371007.7725327, $ellipsoid->getArithmeticMeanRadius(), '', 0.0001);
+        $this->assertEqualsWithDelta(6371007.7725327, $ellipsoid->getArithmeticMeanRadius(), 0.0001, '');
     }
 
     /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Ellipsoid arrays should contain `name`, `a` and `invF` keys !
      * @dataProvider createFromArrayProvider
      */
     public function testCreateFromArrayThrowsException($newEllipsoid)
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Ellipsoid arrays should contain `name`, `a` and `invF` keys !');
         Ellipsoid::createFromArray($newEllipsoid);
     }
 
@@ -149,18 +145,16 @@ class EllipsoidTest extends \League\Geotools\Tests\TestCase
         $this->assertInstanceOf('League\Geotools\Coordinate\Ellipsoid', $ellipsoid);
         $this->assertSame('foo ellipsoid', $ellipsoid->getName());
         $this->assertSame(6378136.0, $ellipsoid->getA());
-        $this->assertEquals(6356751.317598, $ellipsoid->getB(), '', 0.0001);
+        $this->assertEqualsWithDelta(6356751.317598, $ellipsoid->getB(), 0.0001, '');
         $this->assertSame(298.257223563, $ellipsoid->getInvF());
-        $this->assertEquals(6371007.7725327, $ellipsoid->getArithmeticMeanRadius(), '', 0.0001);
+        $this->assertEqualsWithDelta(6371007.7725327, $ellipsoid->getArithmeticMeanRadius(), 0.0001, '');
     }
 
 
-    /**
-     * @expectedException League\Geotools\Exception\NotMatchingEllipsoidException
-     * @expectedExceptionMessage The ellipsoids for both coordinates must match !
-     */
     public function testCoordinatesWithDifferentEllipsoids()
     {
+        $this->expectException(\League\Geotools\Exception\NotMatchingEllipsoidException::class);
+        $this->expectExceptionMessage('The ellipsoids for both coordinates must match !');
         $WGS84       = Ellipsoid::createFromName(Ellipsoid::WGS84);
         $ANOTHER_ONE = Ellipsoid::createFromArray(array(
             'name' => 'foo ellipsoid',

--- a/tests/CoordinateCoupleTest.php
+++ b/tests/CoordinateCoupleTest.php
@@ -16,7 +16,7 @@ use League\Geotools\CoordinateCouple;
 /**
  * @author Antoine Corcy <contact@sbin.dk>
  */
-class CoordinateCoupeTest extends TestCase
+class CoordinateCoupleTest extends TestCase
 {
     protected $geotools;
 

--- a/tests/Distance/DistanceTest.php
+++ b/tests/Distance/DistanceTest.php
@@ -96,19 +96,19 @@ class DistanceTest extends \League\Geotools\Tests\TestCase
     {
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['flat']['m'], $this->distance->flat(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['flat']['m'], $this->distance->flat(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['flat']['km'], $this->distance->in('km')->flat(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['flat']['km'], $this->distance->in('km')->flat(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['flat']['mi'], $this->distance->in('mi')->flat(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['flat']['mi'], $this->distance->in('mi')->flat(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['flat']['ft'], $this->distance->in('ft')->flat(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['flat']['ft'], $this->distance->in('ft')->flat(), 0.00001, '');
     }
 
     /**
@@ -118,19 +118,19 @@ class DistanceTest extends \League\Geotools\Tests\TestCase
     {
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['greatCircle']['m'], $this->distance->greatCircle(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['greatCircle']['m'], $this->distance->greatCircle(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['greatCircle']['km'], $this->distance->in('km')->greatCircle(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['greatCircle']['km'], $this->distance->in('km')->greatCircle(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['greatCircle']['mi'], $this->distance->in('mi')->greatCircle(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['greatCircle']['mi'], $this->distance->in('mi')->greatCircle(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['greatCircle']['ft'], $this->distance->in('ft')->greatCircle(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['greatCircle']['ft'], $this->distance->in('ft')->greatCircle(), 0.00001, '');
     }
 
     /**
@@ -140,19 +140,19 @@ class DistanceTest extends \League\Geotools\Tests\TestCase
     {
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['haversine']['m'], $this->distance->haversine(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['haversine']['m'], $this->distance->haversine(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['haversine']['km'], $this->distance->in('km')->haversine(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['haversine']['km'], $this->distance->in('km')->haversine(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['haversine']['mi'], $this->distance->in('mi')->haversine(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['haversine']['mi'], $this->distance->in('mi')->haversine(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['haversine']['ft'], $this->distance->in('ft')->haversine(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['haversine']['ft'], $this->distance->in('ft')->haversine(), 0.00001, '');
     }
 
     /**
@@ -162,19 +162,19 @@ class DistanceTest extends \League\Geotools\Tests\TestCase
     {
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['vincenty']['m'], $this->distance->vincenty(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['vincenty']['m'], $this->distance->vincenty(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['vincenty']['km'], $this->distance->in('km')->vincenty(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['vincenty']['km'], $this->distance->in('km')->vincenty(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['vincenty']['mi'], $this->distance->in('mi')->vincenty(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['vincenty']['mi'], $this->distance->in('mi')->vincenty(), 0.00001, '');
 
         $this->distance->setFrom($this->getMockCoordinateReturns($this->coordA, $ellipsoid));
         $this->distance->setTo($this->getMockCoordinateReturns($this->coordB, $ellipsoid));
-        $this->assertEquals($result['vincenty']['ft'], $this->distance->in('ft')->vincenty(), '', 0.00001);
+        $this->assertEqualsWithDelta($result['vincenty']['ft'], $this->distance->in('ft')->vincenty(), 0.00001, '');
     }
 
     public function ellipsoidInstanceAndExpectedResultProvider()

--- a/tests/Geohash/GeohashTest.php
+++ b/tests/Geohash/GeohashTest.php
@@ -26,12 +26,12 @@ class GeohashTest extends \League\Geotools\Tests\TestCase
     }
 
     /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The length should be between 1 and 12.
      * @dataProvider lengthsProvider
      */
     public function testEncodeShouldThrowException($length)
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The length should be between 1 and 12.');
         $this->geohash->encode($this->getStubCoordinate(), $length);
     }
 
@@ -60,12 +60,12 @@ class GeohashTest extends \League\Geotools\Tests\TestCase
     }
 
     /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The geo hash should be a string.
      * @dataProvider invalidStringGeoHashesProvider
      */
     public function testDecodeShouldThrowStringException($geohash)
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The geo hash should be a string.');
         $this->geohash->decode($geohash);
     }
 
@@ -80,12 +80,12 @@ class GeohashTest extends \League\Geotools\Tests\TestCase
     }
 
     /**
-     * @expectedException League\Geotools\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The length of the geo hash should be between 1 and 12.
      * @dataProvider invalidRangeGeoHashesProvider
      */
     public function testDecodeShouldThrowRangeException($geohash)
     {
+        $this->expectException(\League\Geotools\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The length of the geo hash should be between 1 and 12.');
         $this->geohash->decode($geohash);
     }
 
@@ -100,12 +100,12 @@ class GeohashTest extends \League\Geotools\Tests\TestCase
     }
 
     /**
-     * @expectedException League\Geotools\Exception\RuntimeException
-     * @expectedExceptionMessage This geo hash is invalid.
      * @dataProvider invalidCharGeoHashesProvider
      */
     public function testDecodeShouldThrowRuntimeException($geohash)
     {
+        $this->expectException(\League\Geotools\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('This geo hash is invalid.');
         $this->geohash->decode($geohash);
     }
 
@@ -154,14 +154,14 @@ class GeohashTest extends \League\Geotools\Tests\TestCase
         $this->assertTrue(is_object($boundingBox[0]));
         $this->assertInstanceOf('\League\Geotools\Coordinate\Coordinate', $boundingBox[0]);
         $this->assertInstanceOf('\League\Geotools\Coordinate\CoordinateInterface', $boundingBox[0]);
-        $this->assertEquals($expectedBoundingBox[0][0], $boundingBox[0]->getLatitude(), '', 0.1);
-        $this->assertEquals($expectedBoundingBox[0][1], $boundingBox[0]->getLongitude(), '', 0.1);
+        $this->assertEqualsWithDelta($expectedBoundingBox[0][0], $boundingBox[0]->getLatitude(), 0.1, '');
+        $this->assertEqualsWithDelta($expectedBoundingBox[0][1], $boundingBox[0]->getLongitude(), 0.1, '');
 
         $this->assertTrue(is_object($boundingBox[1]));
         $this->assertInstanceOf('\League\Geotools\Coordinate\Coordinate', $boundingBox[1]);
         $this->assertInstanceOf('\League\Geotools\Coordinate\CoordinateInterface', $boundingBox[1]);
-        $this->assertEquals($expectedBoundingBox[1][0], $boundingBox[1]->getLatitude(), '', 0.1);
-        $this->assertEquals($expectedBoundingBox[1][1], $boundingBox[1]->getLongitude(), '', 0.1);
+        $this->assertEqualsWithDelta($expectedBoundingBox[1][0], $boundingBox[1]->getLatitude(), 0.1, '');
+        $this->assertEqualsWithDelta($expectedBoundingBox[1][1], $boundingBox[1]->getLongitude(), 0.1, '');
     }
 
     public function coordinatesAndExpectedGeohashesAndBoundingBoxesProvider()
@@ -207,8 +207,8 @@ class GeohashTest extends \League\Geotools\Tests\TestCase
         $this->assertTrue(is_object($coordinate));
         $this->assertInstanceOf('\League\Geotools\Coordinate\Coordinate', $coordinate);
         $this->assertInstanceOf('\League\Geotools\Coordinate\CoordinateInterface', $coordinate);
-        $this->assertEquals($expectedCoordinate[0], $coordinate->getLatitude(), '', 0.1);
-        $this->assertEquals($expectedCoordinate[1], $coordinate->getLongitude(), '', 0.1);
+        $this->assertEqualsWithDelta($expectedCoordinate[0], $coordinate->getLatitude(), 0.1, '');
+        $this->assertEqualsWithDelta($expectedCoordinate[1], $coordinate->getLongitude(), 0.1, '');
     }
 
     /**
@@ -222,14 +222,14 @@ class GeohashTest extends \League\Geotools\Tests\TestCase
         $this->assertTrue(is_object($boundingBox[0]));
         $this->assertInstanceOf('\League\Geotools\Coordinate\Coordinate', $boundingBox[0]);
         $this->assertInstanceOf('\League\Geotools\Coordinate\CoordinateInterface', $boundingBox[0]);
-        $this->assertEquals($expectedBoundingBox[0][0], $boundingBox[0]->getLatitude(), '', 0.1);
-        $this->assertEquals($expectedBoundingBox[0][1], $boundingBox[0]->getLongitude(), '', 0.1);
+        $this->assertEqualsWithDelta($expectedBoundingBox[0][0], $boundingBox[0]->getLatitude(), 0.1, '');
+        $this->assertEqualsWithDelta($expectedBoundingBox[0][1], $boundingBox[0]->getLongitude(), 0.1, '');
 
         $this->assertTrue(is_object($boundingBox[1]));
         $this->assertInstanceOf('\League\Geotools\Coordinate\Coordinate', $boundingBox[1]);
         $this->assertInstanceOf('\League\Geotools\Coordinate\CoordinateInterface', $boundingBox[1]);
-        $this->assertEquals($expectedBoundingBox[1][0], $boundingBox[1]->getLatitude(), '', 0.1);
-        $this->assertEquals($expectedBoundingBox[1][1], $boundingBox[1]->getLongitude(), '', 0.1);
+        $this->assertEqualsWithDelta($expectedBoundingBox[1][0], $boundingBox[1]->getLatitude(), 0.1, '');
+        $this->assertEqualsWithDelta($expectedBoundingBox[1][1], $boundingBox[1]->getLongitude(), 0.1, '');
     }
 
     public function geohashesAndExpectedCoordinatesAndBoundingBoxesProvider()

--- a/tests/Polygon/PolygonTest.php
+++ b/tests/Polygon/PolygonTest.php
@@ -29,19 +29,15 @@ class PolygonTest extends \League\Geotools\Tests\TestCase
         $this->polygon = new Polygon;
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testCannotCreatePolygonWithString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Polygon('foo');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testCannotCreatePolygonWithInteger()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Polygon(123);
     }
 
@@ -62,6 +58,7 @@ class PolygonTest extends \League\Geotools\Tests\TestCase
     /**
      * @dataProvider polygonCoordinates
      * @param array $polygonCoordinates
+     * @doesNotPerformAssertions
      */
     public function testContructor($polygonCoordinates)
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,10 +31,7 @@ abstract class TestCase extends PHPUnitTestCase
      */
     protected function getStubGeocoder()
     {
-        $stub = $this
-            ->getMockBuilder('\Geocoder\ProviderAggregator')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $stub = $this->createMock('\Geocoder\ProviderAggregator');
 
         return $stub;
     }
@@ -53,21 +50,17 @@ abstract class TestCase extends PHPUnitTestCase
             $addresses = new AddressCollection([Address::createFromArray($data)]);
         }
 
-        $mock = $this->getMockBuilder('\Geocoder\ProviderAggregator')->getMock();
+        $mock = $this->createMock('\Geocoder\ProviderAggregator');
         $mock
-            ->expects($this->any())
             ->method('getProviders')
             ->will($this->returnValue($providers));
         $mock
-            ->expects($this->any())
             ->method('using')
             ->will($this->returnSelf());
         $mock
-            ->expects($this->any())
             ->method('geocode')
             ->will($this->returnValue($addresses));
         $mock
-            ->expects($this->any())
             ->method('reverse')
             ->will($this->returnValue($addresses));
 
@@ -81,21 +74,18 @@ abstract class TestCase extends PHPUnitTestCase
      */
     protected function getMockGeocoderThrowException(array $providers)
     {
-        $mock = $this->getMockBuilder('\Geocoder\ProviderAggregator')->getMock();
+        $mock = $this->createMock('\Geocoder\ProviderAggregator');
         $mock
             ->expects($this->once())
             ->method('getProviders')
             ->will($this->returnValue($providers));
         $mock
-            ->expects($this->any())
             ->method('using')
             ->will($this->returnSelf());
         $mock
-            ->expects($this->any())
             ->method('geocode')
             ->will($this->throwException(new \Exception));
         $mock
-            ->expects($this->any())
             ->method('reverse')
             ->will($this->throwException(new \Exception));
 
@@ -109,10 +99,7 @@ abstract class TestCase extends PHPUnitTestCase
      */
     protected function getStubCoordinate($lat = null, $lng = null)
     {
-        $stub = $this
-            ->getMockBuilder('\League\Geotools\Coordinate\CoordinateInterface')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $stub = $this->createMock('\League\Geotools\Coordinate\CoordinateInterface');
 
         if (null !== $lat) {
             $stub->method('getLatitude')->willReturn($lat);
@@ -132,13 +119,11 @@ abstract class TestCase extends PHPUnitTestCase
      */
     protected function getMockCoordinateReturns(array $coordinate, Ellipsoid $ellipsoid = null)
     {
-        $mock = $this->getMockBuilder('\League\Geotools\Coordinate\CoordinateInterface')->getMock();
+        $mock = $this->createMock('\League\Geotools\Coordinate\CoordinateInterface');
         $mock
-            ->expects($this->any())
             ->method('getLatitude')
             ->will($this->returnValue($coordinate[0]));
         $mock
-            ->expects($this->any())
             ->method('getLongitude')
             ->will($this->returnValue($coordinate[1]));
 
@@ -163,7 +148,7 @@ abstract class TestCase extends PHPUnitTestCase
             $expects = $this->once();
         }
 
-        $mock = $this->getMockBuilder('\League\Geotools\Batch\BatchGeocoded')->getMock();
+        $mock = $this->createMock('\League\Geotools\Batch\BatchGeocoded');
         $mock
             ->expects($expects)
             ->method('getCoordinates')
@@ -179,7 +164,7 @@ abstract class TestCase extends PHPUnitTestCase
      */
     protected function getMockGeocodedReturns(array $coordinate)
     {
-        $mock = $this->getMockBuilder('\League\Geotools\Batch\BatchGeocoded')->getMock();
+        $mock = $this->createMock('\League\Geotools\Batch\BatchGeocoded');
         $mock
             ->expects($this->atLeastOnce())
             ->method('getLatitude')
@@ -197,15 +182,12 @@ abstract class TestCase extends PHPUnitTestCase
      */
     protected function getStubBatchGeocoded()
     {
-        $stub = $this
-            ->getMockBuilder('\League\Geotools\Batch\BatchGeocoded')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $stub = $this->createMock('\League\Geotools\Batch\BatchGeocoded');
 
-        $stub->expects($this->any())
+        $stub
             ->method('getProviderName')
             ->willReturn('provider');
-        $stub->expects($this->any())
+        $stub
             ->method('getQuery')
             ->willReturn('query');
 
@@ -219,17 +201,15 @@ abstract class TestCase extends PHPUnitTestCase
      */
     protected function getMockCacheReturns($returnValue)
     {
-        $item = $this->getMockBuilder(CacheItemInterface::class)->getMock();
+        $item = $this->createMock(CacheItemInterface::class);
         $item
-            ->expects($this->any())
             ->method('get')
             ->willReturn($returnValue);
         $item
-            ->expects($this->any())
             ->method('isHit')
             ->willReturn(true);
 
-        $mock = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();
+        $mock = $this->createMock(CacheItemPoolInterface::class);
         $mock
             ->expects($this->atLeastOnce())
             ->method('getItem')


### PR DESCRIPTION
This PR fixes the PHPUnit deprecation warnings such as 
```
1) League\Geotools\Tests\Batch\BatchTest::testGeocodeShouldThrowInvalidArgumentException with data set #0 (0)

The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageRegExp() instead.
```