### PR TITLE
Fix incompatibility with PHP >= 7.4

### DIFF
--- a/src/Coordinate/Coordinate.php
+++ b/src/Coordinate/Coordinate.php
@@ -84,7 +84,9 @@ class Coordinate implements CoordinateInterface, \JsonSerializable
      */
     public function normalizeLatitude($latitude)
     {
-        return (double) max(-90, min(90, $latitude));
+        $latitude = rtrim(sprintf('%.13f', max(-90, min(90, $latitude))), 0);
+
+        return '.' === substr($latitude, -1) ? $latitude . '0' : $latitude;
     }
 
     /**
@@ -93,13 +95,14 @@ class Coordinate implements CoordinateInterface, \JsonSerializable
     public function normalizeLongitude($longitude)
     {
         if (180 === $longitude % 360) {
-            return 180.0;
+            return '180.0';
         }
 
         $mod       = fmod($longitude, 360);
         $longitude = $mod < -180 ? $mod + 360 : ($mod > 180 ? $mod - 360 : $mod);
+        $longitude = rtrim(sprintf('%.13f', $longitude), 0);
 
-        return (double) $longitude;
+        return '.' === substr($longitude, -1) ? $longitude . '0' : $longitude;
     }
 
     /**

--- a/src/Coordinate/CoordinateInterface.php
+++ b/src/Coordinate/CoordinateInterface.php
@@ -24,7 +24,7 @@ interface CoordinateInterface
      *
      * @param double $latitude The latitude to normalize
      *
-     * @return double
+     * @return string
      */
     public function normalizeLatitude($latitude);
 
@@ -34,7 +34,7 @@ interface CoordinateInterface
      *
      * @param double $longitude The longitude to normalize
      *
-     * @return double
+     * @return string
      */
     public function normalizeLongitude($longitude);
 
@@ -48,7 +48,7 @@ interface CoordinateInterface
     /**
      * Get the latitude.
      *
-     * @return double
+     * @return string
      */
     public function getLatitude();
 
@@ -62,7 +62,7 @@ interface CoordinateInterface
     /**
      * Get the longitude.
      *
-     * @return double
+     * @return string
      */
     public function getLongitude();
 

--- a/tests/CLI/Command/Geohash/DecodeTest.php
+++ b/tests/CLI/Command/Geohash/DecodeTest.php
@@ -72,6 +72,6 @@ class DecodeTest extends \League\Geotools\Tests\TestCase
         ));
 
         $this->assertTrue(is_string($this->commandTester->getDisplay()));
-        $this->assertRegExp('/40\.446195071563, -79\.948862101883/', $this->commandTester->getDisplay());
+        $this->assertRegExp('/40\.4461950715631, -79\.9488621018827/', $this->commandTester->getDisplay());
     }
 }

--- a/tests/CLI/Command/Vertex/DestinationTest.php
+++ b/tests/CLI/Command/Vertex/DestinationTest.php
@@ -65,7 +65,7 @@ class DestinationTest extends \League\Geotools\Tests\TestCase
         ));
 
         $this->assertTrue(is_string($this->commandTester->getDisplay()));
-        $this->assertRegExp('/47\.026774650075, 2\.3072664/', $this->commandTester->getDisplay());
+        $this->assertRegExp('/47\.0267746500751, 2\.3072664/', $this->commandTester->getDisplay());
     }
 
     public function testExecuteWithEmptyEllipsoidOption()
@@ -105,7 +105,7 @@ class DestinationTest extends \League\Geotools\Tests\TestCase
         ));
 
         $this->assertTrue(is_string($this->commandTester->getDisplay()));
-        $this->assertRegExp('/40\.279971519453, 24\.637336894406/', $this->commandTester->getDisplay());
+        $this->assertRegExp('/40\.2799715194531, 24\.6373368944057/', $this->commandTester->getDisplay());
     }
 
     public function testExecuteWithEllipsoid_AUSTRALIAN_NATIONAL()
@@ -119,7 +119,7 @@ class DestinationTest extends \League\Geotools\Tests\TestCase
         ));
 
         $this->assertTrue(is_string($this->commandTester->getDisplay()));
-        $this->assertRegExp('/40\.280009426711, 24\.637268024987/', $this->commandTester->getDisplay());
+        $this->assertRegExp('/40\.2800094267106, 24\.6372680249866/', $this->commandTester->getDisplay());
     }
 
     public function testExecuteWithEllipsoid_BESSEL_1841()
@@ -133,6 +133,6 @@ class DestinationTest extends \League\Geotools\Tests\TestCase
         ));
 
         $this->assertTrue(is_string($this->commandTester->getDisplay()));
-        $this->assertRegExp('/40\.278751982466, 24\.639552452771/', $this->commandTester->getDisplay());
+        $this->assertRegExp('/40\.2787519824662, 24\.6395524527712/', $this->commandTester->getDisplay());
     }
 }

--- a/tests/CLI/Command/Vertex/MiddleTest.php
+++ b/tests/CLI/Command/Vertex/MiddleTest.php
@@ -63,7 +63,7 @@ class MiddleTest extends \League\Geotools\Tests\TestCase
         ));
 
         $this->assertTrue(is_string($this->commandTester->getDisplay()));
-        $this->assertRegExp('/38\.068139209793, -53\.187718854545/', $this->commandTester->getDisplay());
+        $this->assertRegExp('/38\.0681392097933, -53\.1877188545446/', $this->commandTester->getDisplay());
     }
 
     public function testExecuteWithEmptyEllipsoidOption()
@@ -100,6 +100,6 @@ class MiddleTest extends \League\Geotools\Tests\TestCase
         ));
 
         $this->assertTrue(is_string($this->commandTester->getDisplay()));
-        $this->assertRegExp('/38\.068139209793, -53\.187718854545/', $this->commandTester->getDisplay());
+        $this->assertRegExp('/38\.0681392097933, -53\.1877188545446/', $this->commandTester->getDisplay());
     }
 }

--- a/tests/Coordinate/CoordinateTest.php
+++ b/tests/Coordinate/CoordinateTest.php
@@ -86,83 +86,83 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
         return array(
             array(
                 array(1, 2),
-                array(1.0, 2.0)
+                array('1.0', '2.0')
             ),
             array(
                 array(-1, -2),
-                array(-1.0, -2.0)
+                array('-1.0', '-2.0')
             ),
             array(
                 array('1', '2'),
-                array(1.0, 2.0),
+                array('1.0', '2.0'),
             ),
             array(
                 array('-1', '-2'),
-                array(-1.0, -2.0)
+                array('-1.0', '-2.0')
             ),
             array(
                 '10.0, 20.0',
-                array(10.0, 20.0)
+                array('10.0', '20.0')
             ),
             array(
                 '-10.0,-20.0',
-                array(-10.0, -20.0)
+                array('-10.0', '-20.0')
             ),
             array(
                 '40° 26.7717, -79° 56.93172',
-                array(40.446195, -79.948862)
+                array('40.446195', '-79.948862')
             ),
             array(
                 '40°26.7717 -79°56.93172',
-                array(40.446195, -79.948862)
+                array('40.446195', '-79.948862')
             ),
             array(
                 '40°26.7717S, 79°56.93172E',
-                array(-40.446195, 79.948862)
+                array('-40.446195', '79.948862')
             ),
             array(
                 '40°26.7717N 79°56.93172W',
-                array(40.446195, -79.948862)
+                array('40.446195', '-79.948862')
             ),
             array(
                 '40.446195N,79.948862W',
-                array(40.446195, -79.948862)
+                array('40.446195', '-79.948862')
             ),
             array(
                 '40.446195S 79.948862E',
-                array(-40.446195, 79.948862)
+                array('-40.446195', '79.948862')
             ),
             array(
                 '40:26:46N, 079:56:55W',
-                array(40.446111111111, -79.948611111111)
+                array('40.4461111111111', '-79.9486111111111')
             ),
             array(
                 '40:26:46.302N, 079:56:55.903W',
-                array(40.446195, -79.948861944444)
+                array('40.446195', '-79.9488619444444')
             ),
             array(
                 '40:26:46.302s 079:56:55.903e',
-                array(-40.446195, 79.948861944444)
+                array('-40.446195', '79.9488619444444')
             ),
             array(
                 '25°59.86′N,21°09.81′W',
-                array(25.997666666667, -21.1635)
+                array('25.9976666666667', '-21.1635')
             ),
             array(
                 '40°26′47″N 079°58′36″W',
-                array(40.446388888889, -79.976666666667)
+                array('40.4463888888889', '-79.9766666666667')
             ),
             array(
                 '40 26 47 n 079 58 36 w',
-                array(40.446388888889, -79.976666666667)
+                array('40.4463888888889', '-79.9766666666667')
             ),
             array(
                 '40d 26 47 n 079d 58 36 w',
-                array(40.446388888889, -79.976666666667)
+                array('40.4463888888889', '-79.9766666666667')
             ),
             array(
                 '40d 26′ 47″ N 079d 58′ 36″ W',
-                array(40.446388888889, -79.976666666667)
+                array('40.4463888888889', '-79.9766666666667')
             ),
         );
     }
@@ -183,8 +183,8 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
         $geocoded = $this->createAddress($result);
         $coordinate = new Coordinate($geocoded);
 
-        $this->assertSame((double) $result['latitude'], $coordinate->getLatitude());
-        $this->assertSame((double) $result['longitude'], $coordinate->getLongitude());
+        $this->assertSame((string) $result['latitude'], $coordinate->getLatitude());
+        $this->assertSame((string) $result['longitude'], $coordinate->getLongitude());
     }
 
     public function resultsProvider()
@@ -192,26 +192,26 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
         return array(
             array(
                 array(
-                    'latitude'  => 0.001,
-                    'longitude' => 1,
-                )
-            ),
-            array(
-                array(
-                    'latitude'  => -0.001,
-                    'longitude' => -1,
-                )
-            ),
-            array(
-                array(
                     'latitude'  => '0.001',
-                    'longitude' => '1',
+                    'longitude' => '1.0',
                 )
             ),
             array(
                 array(
                     'latitude'  => '-0.001',
-                    'longitude' => '-1',
+                    'longitude' => '-1.0',
+                )
+            ),
+            array(
+                array(
+                    'latitude'  => '0.001',
+                    'longitude' => '1.0',
+                )
+            ),
+            array(
+                array(
+                    'latitude'  => '-0.001',
+                    'longitude' => '-1.0',
                 )
             ),
         );
@@ -230,9 +230,9 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
     public function latitudesWithExpectedLatitudesProvider()
     {
         return array(
-            array(-180, -90.0),
-            array('0', 0.0),
-            array(180, 90.0),
+            array('-180', '-90.0'),
+            array('0', '0.0'),
+            array('180', '90.0'),
         );
     }
 
@@ -249,15 +249,15 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
     public function longitudesWithExpectedLatitudesProvider()
     {
         return array(
-            array(-500, -140.0),
-            array(-360, 0.0),
-            array(-190, 170.0),
-            array(-180, -180.0),
-            array('0', 0.0),
-            array(180, 180.0),
-            array(190, -170.0),
-            array(360, 0.0),
-            array(500, 140.0),
+            array(-500, '-140.0'),
+            array(-360, '0.0'),
+            array(-190, '170.0'),
+            array(-180, '-180.0'),
+            array('0', '0.0'),
+            array(180, '180.0'),
+            array(190, '-170.0'),
+            array(360, '0.0'),
+            array(500, '140.0'),
         );
     }
 
@@ -268,8 +268,12 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
     {
         $coordinate = new Coordinate($this->createEmptyAddress());
         $coordinate->setLatitude($latitude);
+        $expected = (string) floatval($latitude);
+        if (false === strpos($expected, '.')){
+            $expected .= '.0';
+        }
 
-        $this->assertSame((double) $latitude, $coordinate->getLatitude());
+        $this->assertSame($expected, $coordinate->getLatitude());
     }
 
     public function latitudesProvider()
@@ -293,8 +297,12 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
     {
         $coordinate = new Coordinate($this->createEmptyAddress());
         $coordinate->setLongitude($longitude);
+        $expected = (string) floatval($longitude);
+        if (false === strpos($expected, '.')){
+            $expected .= '.0';
+        }
 
-        $this->assertSame((double) $longitude, $coordinate->getLongitude());
+        $this->assertSame($expected, $coordinate->getLongitude());
     }
 
     public function longitudesProvider()
@@ -342,7 +350,7 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
         $coordinate = new Coordinate($this->createEmptyAddress());
         $coordinate->setFromString('40°26′47″N 079°58′36″W');
 
-        $this->assertSame(40.446388888889, $coordinate->getLatitude());
-        $this->assertSame(-79.976666666667, $coordinate->getLongitude());
+        $this->assertSame('40.4463888888889', $coordinate->getLatitude());
+        $this->assertSame('-79.9766666666667', $coordinate->getLongitude());
     }
 }

--- a/tests/Vertex/VertexTest.php
+++ b/tests/Vertex/VertexTest.php
@@ -269,7 +269,7 @@ class VertexTest extends \League\Geotools\Tests\TestCase
             array(
                 array(43.296482, 5.36978),
                 array(48.8234055, 2.3072664),
-                $this->getMockCoordinateReturns(array('46.070143125815', '3.9152401085931'))
+                $this->getMockCoordinateReturns(array('46.0701431258146', '3.9152401085931'))
             ),
             array(
                 array(-13.296482, -5.36978),
@@ -329,7 +329,7 @@ class VertexTest extends \League\Geotools\Tests\TestCase
                 array(43.296482, 5.36978),
                 37,
                 3000,
-                $this->getMockCoordinateReturns(array('43.318002633989', '5.3920718426221'))
+                $this->getMockCoordinateReturns(array('43.3180026339891', '5.3920718426221'))
             ),
             array(
                 array(-13.296482, -5.36978),


### PR DESCRIPTION
Fixes issue mentioned in #144 

> BCMath functions will now warn if a non well-formed number is passed, such as "32foo". The argument will be interpreted as zero, as before.
See https://www.php.net/manual/en/migration74.incompatible.php

The proposed solution is to save longitude and latitude as a string.