### PR TITLE
update version dependencies of psr/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 
     "require" : {
         "php"                     : "^7.3 || ^7.4 || ^8.0",
-        "psr/cache"               : "^1.0",
+        "psr/cache"               : "^1.0 || ^2.0 || ^3.0",
         "willdurand/geocoder"     : "^4.2",
         "react/promise"           : "^2.2",
         "symfony/console"         : "^3.4 || ^4.4 || ^5.0",


### PR DESCRIPTION
Hi,
Thanks for your great package.
geotools use only the `CacheItemPoolInterface` interface of the psr/cache. and the command
```console
git diff 1.0.1 3.0.0 -- src/CacheItemPoolInterface.php
```
shows that it has only been added type declarations.

As recent versions of frameworks like symfony use at least version 2 you can get stuck.
this pull request therefore proposes to authorize versions 2 and 3 of this package 