### PR TITLE
Suppress deprecation warning for JsonSerializable in PHP 8.1

### DIFF
--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -40,6 +40,7 @@ class ArrayCollection implements \Countable, \IteratorAggregate, \ArrayAccess, \
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->elements;

--- a/src/Coordinate/Coordinate.php
+++ b/src/Coordinate/Coordinate.php
@@ -275,6 +275,7 @@ class Coordinate implements CoordinateInterface, \JsonSerializable
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [$this->latitude, $this->longitude];

--- a/src/Polygon/Polygon.php
+++ b/src/Polygon/Polygon.php
@@ -309,6 +309,7 @@ class Polygon implements PolygonInterface, \Countable, \IteratorAggregate, \Arra
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->coordinates->jsonSerialize();


### PR DESCRIPTION
Since PHP 8.1 there is a warning if `JsonSerializable::jsonSerialize(): mixed` is defined without `mixed` return type. This PR sets the attribute `#[\ReturnTypeWillChange]` to suppress the warnings, so we will still have compatibility with PHP 7.3+.