### PR TITLE
Fix typeerror due to locale decimal separator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+    
+      - name: Generate locales
+        run: sudo apt-get update && sudo apt-get install tzdata locales -y && sudo locale-gen sv_SE && sudo locale-gen sv_SE.UTF-8 && sudo locale-gen en_US && sudo locale-gen en_US.UTF-8
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/src/Coordinate/Coordinate.php
+++ b/src/Coordinate/Coordinate.php
@@ -84,7 +84,7 @@ class Coordinate implements CoordinateInterface, \JsonSerializable
      */
     public function normalizeLatitude($latitude)
     {
-        $latitude = rtrim(sprintf('%.13f', max(-90, min(90, $latitude))), 0);
+        $latitude = rtrim(sprintf('%.13F', max(-90, min(90, $latitude))), 0);
 
         return '.' === substr($latitude, -1) ? $latitude . '0' : $latitude;
     }
@@ -100,7 +100,7 @@ class Coordinate implements CoordinateInterface, \JsonSerializable
 
         $mod       = fmod($longitude, 360);
         $longitude = $mod < -180 ? $mod + 360 : ($mod > 180 ? $mod - 360 : $mod);
-        $longitude = rtrim(sprintf('%.13f', $longitude), 0);
+        $longitude = rtrim(sprintf('%.13F', $longitude), 0);
 
         return '.' === substr($longitude, -1) ? $longitude . '0' : $longitude;
     }

--- a/tests/Coordinate/CoordinateTest.php
+++ b/tests/Coordinate/CoordinateTest.php
@@ -361,4 +361,34 @@ class CoordinateTest extends \League\Geotools\Tests\TestCase
         $this->assertSame('40.4463888888889', $coordinate->getLatitude());
         $this->assertSame('-79.9766666666667', $coordinate->getLongitude());
     }
+
+    public function testSetCoordinateWithLocaleThatUsesDecimalPointAsDecimalSeparator()
+    {
+        $this->setLocale(LC_NUMERIC, 'en_US');
+
+        $latitude = "59.3293235";
+        $longitude = "18.0685808";            
+
+        $coordinate = new Coordinate($this->createEmptyAddress());
+        $coordinate->setLatitude($latitude);
+        $coordinate->setLongitude($longitude);
+
+        $this->assertSame($latitude, $coordinate->getLatitude());
+        $this->assertSame($longitude, $coordinate->getLongitude());
+    }
+
+    public function testSetCoordinateWithLocaleThatUsesDecimalCommaAsDecimalSeparator()
+    {
+        $this->setLocale(LC_NUMERIC, 'sv_SE');
+
+        $latitude = "59.3293235";
+        $longitude = "18.0685808";            
+
+        $coordinate = new Coordinate($this->createEmptyAddress());
+        $coordinate->setLatitude($latitude);
+        $coordinate->setLongitude($longitude);
+
+        $this->assertSame($latitude, $coordinate->getLatitude());
+        $this->assertSame($longitude, $coordinate->getLongitude());
+    }
 }


### PR DESCRIPTION
This pull request fixes a TypeError when using a locale that uses decimal comma as decimal separator.

```php
// Example that triggers error when locale is set to Swedish (sv_SE):

$firstLocation = new \League\Geotools\Coordinate\Coordinate(["59.3293235", "18.0685808"]);
$secondLocation = new \League\Geotools\Coordinate\Coordinate(["59.646492", "17.937797"]);

$geotools = new \League\Geotools\Geotools();
$distanceBetweenLocations = $geotools->distance()->setFrom($firstLocation)->setTo($secondLocation);

// This line causes error "deg2rad(): Argument #1 ($num) must be of type float, string given"
echo "Distance: " . $distanceBetweenLocations->flat();
```

The error is probably caused by the usage of `sprintf` in for example method   
 `normalizeLatitude($latitude)`:
 `$latitude = rtrim(sprintf('%.13f', max(-90, min(90, $latitude))), 0);`
 According to https://www.php.net/manual/en/function.sprintf.php the `f` specifier is locale aware. However the `F` specifier is non-locale aware so I think it should be sufficient to switch to that.

Minimal test that shows the difference when using different locales:

```sh
  
$ php -r "setlocale(LC_ALL, 'en_US'); echo rtrim(sprintf('%.13f', max(-90, min(90, '59.3293235'))), 0);"

Output: 59.3293235

$ php -r "setlocale(LC_ALL, 'sv_SE'); echo rtrim(sprintf('%.13f', max(-90, min(90, '59.3293235'))), 0);"

Output: 59,3293235

```

