### PR TITLE
Fix geohash string type

### DIFF
--- a/src/Geohash/Geohash.php
+++ b/src/Geohash/Geohash.php
@@ -28,14 +28,14 @@ class Geohash implements GeohashInterface
      *
      * @var integer
      */
-    const MIN_LENGTH = 1;
+    public const MIN_LENGTH = 1;
 
     /**
      * The maximum length of the geo hash.
      *
      * @var integer
      */
-    const MAX_LENGTH = 12;
+    public const MAX_LENGTH = 12;
 
 
     /**
@@ -43,7 +43,7 @@ class Geohash implements GeohashInterface
      *
      * @var string
      */
-    protected $geohash;
+    protected $geohash = '';
 
     /**
      * The interval of latitudes in degrees.
@@ -82,7 +82,7 @@ class Geohash implements GeohashInterface
      *
      * @return string
      */
-    public function getGeohash()
+    public function getGeohash(): string
     {
         return $this->geohash;
     }
@@ -105,7 +105,7 @@ class Geohash implements GeohashInterface
      *
      * @return CoordinateInterface[]
      */
-    public function getBoundingBox()
+    public function getBoundingBox(): array
     {
         return array(
             new Coordinate(array(
@@ -125,9 +125,10 @@ class Geohash implements GeohashInterface
      * @see http://en.wikipedia.org/wiki/Geohash
      * @see http://geohash.org/
      */
-    public function encode(CoordinateInterface $coordinate, $length = self::MAX_LENGTH)
+    public function encode(CoordinateInterface $coordinate, $length = self::MAX_LENGTH): GeohashInterface
     {
-        if ((int) $length < self::MIN_LENGTH || (int) $length > self::MAX_LENGTH) {
+        $length = (int) $length;
+        if ($length < self::MIN_LENGTH || $length > self::MAX_LENGTH) {
             throw new InvalidArgumentException('The length should be between 1 and 12.');
         }
 
@@ -159,12 +160,12 @@ class Geohash implements GeohashInterface
             if ($bit < 4) {
                 $bit++;
             } else {
-                $this->geohash = $this->geohash . $this->base32Chars[$charIndex];
+                $this->geohash .= $this->base32Chars[$charIndex];
                 $bit           = 0;
                 $charIndex     = 0;
             }
 
-            $isEven = $isEven ? false : true;
+            $isEven = !$isEven;
         }
 
         $this->latitudeInterval  = $latitudeInterval;
@@ -176,7 +177,7 @@ class Geohash implements GeohashInterface
     /**
      * {@inheritDoc}
      */
-    public function decode($geohash)
+    public function decode($geohash): GeohashInterface
     {
         if (!is_string($geohash)) {
             throw new InvalidArgumentException('The geo hash should be a string.');
@@ -223,7 +224,7 @@ class Geohash implements GeohashInterface
                     }
                 }
 
-                $isEven = $isEven ? false : true;
+                $isEven = !$isEven;
             }
         }
 

--- a/src/Geohash/GeohashInterface.php
+++ b/src/Geohash/GeohashInterface.php
@@ -12,6 +12,8 @@
 namespace League\Geotools\Geohash;
 
 use League\Geotools\Coordinate\CoordinateInterface;
+use League\Geotools\Exception\InvalidArgumentException;
+use League\Geotools\Exception\RuntimeException;
 
 /**
  * Geohash interface
@@ -24,13 +26,13 @@ interface GeohashInterface
      * Returns a geo hash string.
      *
      * @param CoordinateInterface $coordinate The coordinate to encode.
-     * @param integer             $length     The length of the hash between 1 to 12 by default (optional).
+     * @param int                 $length     The length of the hash between 1 and 12 by default.
      *
      * @return GeohashInterface
      *
      * @throws InvalidArgumentException
      */
-    public function encode(CoordinateInterface $coordinate, $length = self::MAX_LENGTH);
+    public function encode(CoordinateInterface $coordinate, $length): GeohashInterface;
 
     /**
      * Returns the decoded geo hash to it's center.
@@ -45,5 +47,5 @@ interface GeohashInterface
      * @throws InvalidArgumentException
      * @throws RuntimeException
      */
-    public function decode($geohash);
+    public function decode($geohash): GeohashInterface;
 }


### PR DESCRIPTION
This PR fixes the `Geohash` class for PHP 8.1 :

```
 strlen(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/league/geotools/src/Geohash/Geohash.php line 140
``` 


If anyone needs to use the Geohash class with PHP 8.1, you can create this one while waiting for this PR to be merged:

```php
use League\Geotools\Geohash\Geohash as Base;

class Geohash extends Base
{
    protected $geohash = '';
}

```