### PR TITLE
Suppress deprecation warnings on PHP 8.1

### DIFF
--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -49,6 +49,7 @@ class ArrayCollection implements \Countable, \IteratorAggregate, \ArrayAccess, \
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->elements[$offset]) || array_key_exists($offset, $this->elements);
@@ -57,6 +58,7 @@ class ArrayCollection implements \Countable, \IteratorAggregate, \ArrayAccess, \
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
@@ -65,6 +67,7 @@ class ArrayCollection implements \Countable, \IteratorAggregate, \ArrayAccess, \
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->set($offset, $value);
@@ -73,6 +76,7 @@ class ArrayCollection implements \Countable, \IteratorAggregate, \ArrayAccess, \
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         return $this->remove($offset);
@@ -81,6 +85,7 @@ class ArrayCollection implements \Countable, \IteratorAggregate, \ArrayAccess, \
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->elements);
@@ -89,6 +94,7 @@ class ArrayCollection implements \Countable, \IteratorAggregate, \ArrayAccess, \
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->elements);

--- a/src/Polygon/Polygon.php
+++ b/src/Polygon/Polygon.php
@@ -318,6 +318,7 @@ class Polygon implements PolygonInterface, \Countable, \IteratorAggregate, \Arra
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->coordinates->offsetExists($offset);
@@ -326,6 +327,7 @@ class Polygon implements PolygonInterface, \Countable, \IteratorAggregate, \Arra
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->coordinates->offsetGet($offset);
@@ -334,6 +336,7 @@ class Polygon implements PolygonInterface, \Countable, \IteratorAggregate, \Arra
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->coordinates->offsetSet($offset, $value);
@@ -343,6 +346,7 @@ class Polygon implements PolygonInterface, \Countable, \IteratorAggregate, \Arra
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $retval = $this->coordinates->offsetUnset($offset);
@@ -353,6 +357,7 @@ class Polygon implements PolygonInterface, \Countable, \IteratorAggregate, \Arra
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->coordinates->count();
@@ -361,6 +366,7 @@ class Polygon implements PolygonInterface, \Countable, \IteratorAggregate, \Arra
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->coordinates->getIterator();


### PR DESCRIPTION
I was getting all sorts of deprecation warnings on PHP 8.1.4. I've just implemented a "fix" similar to how you've previously handled deprecation notices on the `jsonSerialize` method.