### PR TITLE
Moved abandoned cache/array-adapter from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,13 +31,13 @@
         "symfony/serializer"      : "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "react/event-loop"        : "^1.0",
         "php-http/discovery"      : "^1.0",
-        "cache/array-adapter"     : "^1.0",
         "ext-bcmath": "*",
         "ext-json": "*"
     },
 
     "require-dev" : {
-        "phpunit/phpunit"         : "^9.5"
+        "phpunit/phpunit"         : "^9.5",
+        "cache/array-adapter"     : "^1.0"
     },
 
     "autoload" : {


### PR DESCRIPTION
Fixes https://github.com/thephpleague/geotools/issues/190

Many packages nowdays require `psr/cache: 3.0` but `cache/array-adapter` is abandoned and only allows `psr/cache: 1.0 | 2.0`.
Geotools code depends only on `psr/cache`.