### PR TITLE
Update cast/param types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         strategy: [ 'highest' ]
         sf_version: ['']
         include:
@@ -27,6 +27,8 @@ jobs:
             - php: 8.3
               sf_version: '7.*'
             - php: 8.4
+              sf_version: '7.*'
+            - php: 8.5
               sf_version: '7.*'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
               sf_version: '7.*'
             - php: 8.4
               sf_version: '7.*'
-            - php: 8.5
-              sf_version: '7.*'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         strategy: [ 'highest' ]
         sf_version: ['']
         include:

--- a/src/Batch/BatchGeocoded.php
+++ b/src/Batch/BatchGeocoded.php
@@ -147,7 +147,7 @@ class BatchGeocoded
     /**
      * Returns the latitude value.
      *
-     * @return double
+     * @return float
      */
     public function getLatitude()
     {
@@ -161,7 +161,7 @@ class BatchGeocoded
     /**
      * Returns the longitude value.
      *
-     * @return double
+     * @return float
      */
     public function getLongitude()
     {

--- a/src/Coordinate/Coordinate.php
+++ b/src/Coordinate/Coordinate.php
@@ -24,14 +24,14 @@ class Coordinate implements CoordinateInterface, \JsonSerializable
     /**
      * The latitude of the coordinate.
      *
-     * @var double
+     * @var float
      */
     protected $latitude;
 
     /**
      * The longitude of the coordinate.
      *
-     * @var double
+     * @var float
      */
     protected $longitude;
 

--- a/src/Coordinate/CoordinateInterface.php
+++ b/src/Coordinate/CoordinateInterface.php
@@ -22,7 +22,7 @@ interface CoordinateInterface
      * Normalizes a latitude to the (-90, 90) range.
      * Latitudes below -90.0 or above 90.0 degrees are capped, not wrapped.
      *
-     * @param double $latitude The latitude to normalize
+     * @param float $latitude The latitude to normalize
      *
      * @return string
      */
@@ -32,7 +32,7 @@ interface CoordinateInterface
      * Normalizes a longitude to the (-180, 180) range.
      * Longitudes below -180.0 or abode 180.0 degrees are wrapped.
      *
-     * @param double $longitude The longitude to normalize
+     * @param float $longitude The longitude to normalize
      *
      * @return string
      */
@@ -41,7 +41,7 @@ interface CoordinateInterface
     /**
      * Set the latitude.
      *
-     * @param double $latitude
+     * @param float $latitude
      */
     public function setLatitude($latitude);
 
@@ -55,7 +55,7 @@ interface CoordinateInterface
     /**
      * Set the longitude.
      *
-     * @param double $longitude
+     * @param float $longitude
      */
     public function setLongitude($longitude);
 

--- a/src/Coordinate/Ellipsoid.php
+++ b/src/Coordinate/Ellipsoid.php
@@ -65,7 +65,7 @@ class Ellipsoid
      * @see http://en.wikipedia.org/wiki/Earth_radius
      * @see http://home.online.no/~sigurdhu/WGS84_Eng.html
      *
-     * @var double
+     * @var float
      */
     protected $a;
 
@@ -73,7 +73,7 @@ class Ellipsoid
      * The inverse flattening.
      * @see http://home.online.no/~sigurdhu/WGS84_Eng.html
      *
-     * @var double
+     * @var float
      */
     protected $invF;
 
@@ -209,14 +209,14 @@ class Ellipsoid
      * Create a new ellipsoid.
      *
      * @param string $name The name of the ellipsoid to create.
-     * @param double $a    The semi-major axis (equatorial radius) in meters.
-     * @param double $invF The inverse flattening.
+     * @param float $a    The semi-major axis (equatorial radius) in meters.
+     * @param float $invF The inverse flattening.
      *
      * @throws InvalidArgumentException
      */
     public function __construct($name, $a, $invF)
     {
-        if (0.0 >= (double) $invF) {
+        if (0.0 >= (float) $invF) {
             throw new InvalidArgumentException('The inverse flattening cannot be negative or equal to zero !');
         }
 
@@ -294,43 +294,43 @@ class Ellipsoid
     /**
      * Returns the semi-major axis (equatorial radius) in meters.
      *
-     * @return double
+     * @return float
      */
     public function getA()
     {
-        return (double) $this->a;
+        return (float) $this->a;
     }
 
     /**
      * Computes and returns the semi-minor axis (polar distance) in meters.
      * @see http://home.online.no/~sigurdhu/WGS84_Eng.html
      *
-     * @return double
+     * @return float
      */
     public function getB()
     {
-        return (double) $this->a * (1 - 1 / $this->invF);
+        return (float) $this->a * (1 - 1 / $this->invF);
     }
 
     /**
      * Returns the inverse flattening.
      *
-     * @return double
+     * @return float
      */
     public function getInvF()
     {
-        return (double) $this->invF;
+        return (float) $this->invF;
     }
 
     /**
      * Computes and returns the arithmetic mean radius in meters.
      * @see http://home.online.no/~sigurdhu/WGS84_Eng.html
      *
-     * @return double
+     * @return float
      */
     public function getArithmeticMeanRadius()
     {
-        return (double) $this->a * (1 - 1 / $this->invF / 3);
+        return (float) $this->a * (1 - 1 / $this->invF / 3);
     }
 
     /**

--- a/src/Distance/Distance.php
+++ b/src/Distance/Distance.php
@@ -86,7 +86,7 @@ class Distance implements DistanceInterface
      * @see http://en.wikipedia.org/wiki/Pythagorean_theorem
      * @see http://en.wikipedia.org/wiki/Equirectangular_projection
      *
-     * @return double The distance in meters
+     * @return float The distance in meters
      */
     public function flat()
     {
@@ -111,7 +111,7 @@ class Distance implements DistanceInterface
      * @see http://www.ga.gov.au/earth-monitoring/geodesy/geodetic-techniques/distance-calculation-algorithms.html#circle
      * @see http://en.wikipedia.org/wiki/Cosine_law
      *
-     * @return double The distance in meters
+     * @return float The distance in meters
      */
     public function greatCircle()
     {
@@ -136,7 +136,7 @@ class Distance implements DistanceInterface
     * two coordinates using the Haversine formula which is accurate to around 0.3%.
     * @see http://www.movable-type.co.uk/scripts/latlong.html
     *
-    * @return double The distance in meters
+    * @return float The distance in meters
     */
     public function haversine()
     {
@@ -161,7 +161,7 @@ class Distance implements DistanceInterface
     * formula for ellipsoids which is accurate to within 0.5mm.
     * @see http://www.movable-type.co.uk/scripts/latlong-vincenty.html
     *
-    * @return double The distance in meters
+    * @return float The distance in meters
     */
     public function vincenty()
     {
@@ -229,9 +229,9 @@ class Distance implements DistanceInterface
      * Converts results in meters to user's unit (if any).
      * The default returned value is in meters.
      *
-     * @param double $meters
+     * @param float $meters
      *
-     * @return double
+     * @return float
      */
     protected function convertToUserUnit($meters)
     {

--- a/src/GeotoolsInterface.php
+++ b/src/GeotoolsInterface.php
@@ -30,21 +30,21 @@ interface GeotoolsInterface
      * Transverse Mercator is not the same as UTM.
      * A scale factor is required to convert between them.
      *
-     * @var double
+     * @var float
      */
     const UTM_SCALE_FACTOR = 0.9996;
 
     /**
      * The ratio meters per mile.
      *
-     * @var double
+     * @var float
      */
     const METERS_PER_MILE = 1609.344;
 
     /**
      * The ratio feet per meter.
      *
-     * @var double
+     * @var float
      */
     const FEET_PER_METER = 0.3048;
 

--- a/src/Vertex/Vertex.php
+++ b/src/Vertex/Vertex.php
@@ -27,12 +27,12 @@ class Vertex implements VertexInterface
     use CoordinateCouple;
 
     /**
-     * @var double
+     * @var float
      */
     protected $gradient;
 
     /**
-     * @var double
+     * @var float
      */
     protected $ordinateIntercept;
 
@@ -187,7 +187,7 @@ class Vertex implements VertexInterface
     {
         Ellipsoid::checkCoordinatesEllipsoid($this->from, $this->to);
 
-        return Geotools::$cardinalPoints[(integer) round($this->initialBearing() / 22.5)];
+        return Geotools::$cardinalPoints[(int) round($this->initialBearing() / 22.5)];
     }
 
     /**
@@ -201,7 +201,7 @@ class Vertex implements VertexInterface
     {
         Ellipsoid::checkCoordinatesEllipsoid($this->from, $this->to);
 
-        return Geotools::$cardinalPoints[(integer) round($this->finalBearing() / 22.5)];
+        return Geotools::$cardinalPoints[(int) round($this->finalBearing() / 22.5)];
     }
 
     /**


### PR DESCRIPTION
I noticed deprecation warnings in production (running PHP 8.5):

```
WARNING
Non-canonical cast (integer) is deprecated, use the (int) cast instead in /app/vendor/league/geotools/src/Vertex/Vertex.php on line 190
 
WARNING
Non-canonical cast (double) is deprecated, use the (float) cast instead in /app/vendor/league/geotools/src/Coordinate/Ellipsoid.php on line 301
```

I believe this is a backwards-compatible change - replacing `double` with `float` and `integer` with `int` to silence the warnings.